### PR TITLE
Import rest poses using ufbx

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -487,8 +487,9 @@ void _apply_scale_to_scalable_node_collection(ScalableNodeCollection &p_collecti
 		if (skeleton_3d) {
 			for (int i = 0; i < skeleton_3d->get_bone_count(); i++) {
 				Transform3D rest = skeleton_3d->get_bone_rest(i);
+				Vector3 position = skeleton_3d->get_bone_pose_position(i);
 				skeleton_3d->set_bone_rest(i, Transform3D(rest.basis, p_scale * rest.origin));
-				skeleton_3d->set_bone_pose_position(i, p_scale * rest.origin);
+				skeleton_3d->set_bone_pose_position(i, p_scale * position);
 			}
 		}
 	}

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -337,6 +337,20 @@ Error FBXDocument::_parse_nodes(Ref<FBXState> p_state) {
 
 			node->xform.basis.set_quaternion_scale(node->rotation, node->scale);
 			node->xform.origin = node->position;
+
+			if (fbx_node->bind_pose) {
+				ufbx_bone_pose *pose = ufbx_get_bone_pose(fbx_node->bind_pose, fbx_node);
+				ufbx_transform rest_transform = ufbx_matrix_to_transform(&pose->bone_to_parent);
+
+				Vector3 rest_position = _as_vec3(rest_transform.translation);
+				Quaternion rest_rotation = _as_quaternion(rest_transform.rotation);
+				Vector3 rest_scale = _as_vec3(rest_transform.scale);
+
+				node->rest_xform.basis.set_quaternion_scale(rest_rotation, rest_scale);
+				node->rest_xform.origin = rest_position;
+			} else {
+				node->rest_xform = node->xform;
+			}
 		}
 
 		for (const ufbx_node *child : fbx_node->children) {

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -606,6 +606,7 @@ Error GLTFDocument::_parse_nodes(Ref<GLTFState> p_state) {
 
 			node->xform.basis.set_quaternion_scale(node->rotation, node->scale);
 			node->xform.origin = node->position;
+			node->rest_xform = node->xform;
 		}
 
 		if (n.has("extensions")) {

--- a/modules/gltf/structures/gltf_node.cpp
+++ b/modules/gltf/structures/gltf_node.cpp
@@ -37,6 +37,8 @@ void GLTFNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_height", "height"), &GLTFNode::set_height);
 	ClassDB::bind_method(D_METHOD("get_xform"), &GLTFNode::get_xform);
 	ClassDB::bind_method(D_METHOD("set_xform", "xform"), &GLTFNode::set_xform);
+	ClassDB::bind_method(D_METHOD("get_rest_xform"), &GLTFNode::get_rest_xform);
+	ClassDB::bind_method(D_METHOD("set_rest_xform", "rest_xform"), &GLTFNode::set_rest_xform);
 	ClassDB::bind_method(D_METHOD("get_mesh"), &GLTFNode::get_mesh);
 	ClassDB::bind_method(D_METHOD("set_mesh", "mesh"), &GLTFNode::set_mesh);
 	ClassDB::bind_method(D_METHOD("get_camera"), &GLTFNode::get_camera);
@@ -61,6 +63,7 @@ void GLTFNode::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "parent"), "set_parent", "get_parent"); // GLTFNodeIndex
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "height"), "set_height", "get_height"); // int
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM3D, "xform"), "set_xform", "get_xform"); // Transform3D
+	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM3D, "rest_xform"), "set_rest_xform", "get_rest_xform"); // Transform3D
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mesh"), "set_mesh", "get_mesh"); // GLTFMeshIndex
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "camera"), "set_camera", "get_camera"); // GLTFCameraIndex
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "skin"), "set_skin", "get_skin"); // GLTFSkinIndex
@@ -94,6 +97,14 @@ Transform3D GLTFNode::get_xform() {
 
 void GLTFNode::set_xform(Transform3D p_xform) {
 	xform = p_xform;
+}
+
+Transform3D GLTFNode::get_rest_xform() {
+	return rest_xform;
+}
+
+void GLTFNode::set_rest_xform(Transform3D p_rest_xform) {
+	rest_xform = p_rest_xform;
 }
 
 GLTFMeshIndex GLTFNode::get_mesh() {

--- a/modules/gltf/structures/gltf_node.h
+++ b/modules/gltf/structures/gltf_node.h
@@ -47,6 +47,7 @@ private:
 	GLTFNodeIndex parent = -1;
 	int height = -1;
 	Transform3D xform;
+	Transform3D rest_xform;
 	GLTFMeshIndex mesh = -1;
 	GLTFCameraIndex camera = -1;
 	GLTFSkinIndex skin = -1;
@@ -71,6 +72,9 @@ public:
 
 	Transform3D get_xform();
 	void set_xform(Transform3D p_xform);
+
+	Transform3D get_rest_xform();
+	void set_rest_xform(Transform3D p_rest_xform);
 
 	GLTFMeshIndex get_mesh();
 	void set_mesh(GLTFMeshIndex p_mesh);

--- a/scene/resources/skin_tool.cpp
+++ b/scene/resources/skin_tool.cpp
@@ -592,7 +592,7 @@ Error SkinTool::_create_skeletons(
 			node->set_name(_gen_unique_bone_name(unique_names, node->get_name()));
 
 			skeleton->add_bone(node->get_name());
-			skeleton->set_bone_rest(bone_index, node->xform);
+			skeleton->set_bone_rest(bone_index, node->rest_xform);
 			skeleton->set_bone_pose_position(bone_index, node->position);
 			skeleton->set_bone_pose_rotation(bone_index, node->rotation.normalized());
 			skeleton->set_bone_pose_scale(bone_index, node->scale);


### PR DESCRIPTION
Import skeleton rest positions if FBX defines bind poses.

Breaks compatibility with FBX2glTF, should probably be an option?

Modifies the behavior of `_apply_scale_to_scalable_node_collection()` as that resets all bone positions to bind pose when scaling..