### PR TITLE
Store the original non-unique node, mesh and animation names in FBX and glTF

### DIFF
--- a/modules/gltf/structures/gltf_animation.cpp
+++ b/modules/gltf/structures/gltf_animation.cpp
@@ -31,12 +31,23 @@
 #include "gltf_animation.h"
 
 void GLTFAnimation::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_original_name"), &GLTFAnimation::get_original_name);
+	ClassDB::bind_method(D_METHOD("set_original_name", "original_name"), &GLTFAnimation::set_original_name);
 	ClassDB::bind_method(D_METHOD("get_loop"), &GLTFAnimation::get_loop);
 	ClassDB::bind_method(D_METHOD("set_loop", "loop"), &GLTFAnimation::set_loop);
 	ClassDB::bind_method(D_METHOD("get_additional_data", "extension_name"), &GLTFAnimation::get_additional_data);
 	ClassDB::bind_method(D_METHOD("set_additional_data", "extension_name", "additional_data"), &GLTFAnimation::set_additional_data);
 
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "original_name"), "set_original_name", "get_original_name"); // String
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "loop"), "set_loop", "get_loop"); // bool
+}
+
+String GLTFAnimation::get_original_name() {
+	return original_name;
+}
+
+void GLTFAnimation::set_original_name(String p_name) {
+	original_name = p_name;
 }
 
 bool GLTFAnimation::get_loop() const {

--- a/modules/gltf/structures/gltf_animation.h
+++ b/modules/gltf/structures/gltf_animation.h
@@ -62,6 +62,9 @@ public:
 	};
 
 public:
+	String get_original_name();
+	void set_original_name(String p_name);
+
 	bool get_loop() const;
 	void set_loop(bool p_val);
 	HashMap<int, GLTFAnimation::Track> &get_tracks();
@@ -70,6 +73,7 @@ public:
 	GLTFAnimation();
 
 private:
+	String original_name;
 	bool loop = false;
 	HashMap<int, Track> tracks;
 	Dictionary additional_data;

--- a/modules/gltf/structures/gltf_mesh.cpp
+++ b/modules/gltf/structures/gltf_mesh.cpp
@@ -33,6 +33,8 @@
 #include "scene/resources/importer_mesh.h"
 
 void GLTFMesh::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_original_name"), &GLTFMesh::get_original_name);
+	ClassDB::bind_method(D_METHOD("set_original_name", "original_name"), &GLTFMesh::set_original_name);
 	ClassDB::bind_method(D_METHOD("get_mesh"), &GLTFMesh::get_mesh);
 	ClassDB::bind_method(D_METHOD("set_mesh", "mesh"), &GLTFMesh::set_mesh);
 	ClassDB::bind_method(D_METHOD("get_blend_weights"), &GLTFMesh::get_blend_weights);
@@ -42,9 +44,18 @@ void GLTFMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_additional_data", "extension_name"), &GLTFMesh::get_additional_data);
 	ClassDB::bind_method(D_METHOD("set_additional_data", "extension_name", "additional_data"), &GLTFMesh::set_additional_data);
 
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "original_name"), "set_original_name", "get_original_name");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh"), "set_mesh", "get_mesh");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_FLOAT32_ARRAY, "blend_weights"), "set_blend_weights", "get_blend_weights"); // Vector<float>
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "instance_materials"), "set_instance_materials", "get_instance_materials");
+}
+
+String GLTFMesh::get_original_name() {
+	return original_name;
+}
+
+void GLTFMesh::set_original_name(String p_name) {
+	original_name = p_name;
 }
 
 Ref<ImporterMesh> GLTFMesh::get_mesh() {

--- a/modules/gltf/structures/gltf_mesh.h
+++ b/modules/gltf/structures/gltf_mesh.h
@@ -39,6 +39,7 @@ class GLTFMesh : public Resource {
 	GDCLASS(GLTFMesh, Resource);
 
 private:
+	String original_name;
 	Ref<ImporterMesh> mesh;
 	Vector<float> blend_weights;
 	TypedArray<Material> instance_materials;
@@ -48,6 +49,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	String get_original_name();
+	void set_original_name(String p_name);
 	Ref<ImporterMesh> get_mesh();
 	void set_mesh(Ref<ImporterMesh> p_mesh);
 	Vector<float> get_blend_weights();

--- a/modules/gltf/structures/gltf_node.cpp
+++ b/modules/gltf/structures/gltf_node.cpp
@@ -31,6 +31,8 @@
 #include "gltf_node.h"
 
 void GLTFNode::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_original_name"), &GLTFNode::get_original_name);
+	ClassDB::bind_method(D_METHOD("set_original_name", "original_name"), &GLTFNode::set_original_name);
 	ClassDB::bind_method(D_METHOD("get_parent"), &GLTFNode::get_parent);
 	ClassDB::bind_method(D_METHOD("set_parent", "parent"), &GLTFNode::set_parent);
 	ClassDB::bind_method(D_METHOD("get_height"), &GLTFNode::get_height);
@@ -58,6 +60,7 @@ void GLTFNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_additional_data", "extension_name"), &GLTFNode::get_additional_data);
 	ClassDB::bind_method(D_METHOD("set_additional_data", "extension_name", "additional_data"), &GLTFNode::set_additional_data);
 
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "original_name"), "set_original_name", "get_original_name"); // String
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "parent"), "set_parent", "get_parent"); // GLTFNodeIndex
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "height"), "set_height", "get_height"); // int
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM3D, "xform"), "set_xform", "get_xform"); // Transform3D
@@ -70,6 +73,13 @@ void GLTFNode::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "scale"), "set_scale", "get_scale"); // Vector3
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT32_ARRAY, "children"), "set_children", "get_children"); // Vector<int>
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "light"), "set_light", "get_light"); // GLTFLightIndex
+}
+
+String GLTFNode::get_original_name() {
+	return original_name;
+}
+void GLTFNode::set_original_name(String p_name) {
+	original_name = p_name;
 }
 
 GLTFNodeIndex GLTFNode::get_parent() {

--- a/modules/gltf/structures/gltf_node.h
+++ b/modules/gltf/structures/gltf_node.h
@@ -43,6 +43,7 @@ class GLTFNode : public Resource {
 	friend class FBXDocument;
 
 private:
+	String original_name;
 	GLTFNodeIndex parent = -1;
 	int height = -1;
 	Transform3D transform;
@@ -59,6 +60,9 @@ protected:
 	static void _bind_methods();
 
 public:
+	String get_original_name();
+	void set_original_name(String p_name);
+
 	GLTFNodeIndex get_parent();
 	void set_parent(GLTFNodeIndex p_parent);
 


### PR DESCRIPTION
Seems to correctly store the original node names. I was able to test and it enables using ufbx correctly with Unidot importer.