### PR TITLE
LibGodot Feature

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -216,6 +216,14 @@ opts.Add("custom_modules", "A list of comma-separated directory paths containing
 opts.Add(BoolVariable("custom_modules_recursive", "Detect custom modules recursively for each specified path.", True))
 
 # Advanced options
+opts.Add(
+    EnumVariable(
+        "library_type",
+        "Build library type",
+        "executable",
+        ("executable", "static_library", "shared_library"),
+    )
+)
 opts.Add(BoolVariable("dev_mode", "Alias for dev options: verbose=yes warnings=extra werror=yes tests=yes", False))
 opts.Add(BoolVariable("tests", "Build the unit tests", False))
 opts.Add(BoolVariable("fast_unsafe", "Enable unsafe options for faster rebuilds", False))
@@ -301,6 +309,15 @@ if env["import_env_vars"]:
 # Platform selection: validate input, and add options.
 
 selected_platform = env["platform"]
+
+if env["library_type"] == "static_library":
+    env.Append(CPPDEFINES=["LIBRARY_ENABLED"])
+elif env["library_type"] == "shared_library":
+    env.Append(CPPDEFINES=["LIBRARY_ENABLED"])
+    env.Append(CCFLAGS=["-fPIC"])
+    env.Append(STATIC_AND_SHARED_OBJECTS_ARE_THE_SAME=True)
+else:
+    env.__class__.add_program = methods.add_program
 
 if env.scons_version < (4, 3) and not selected_platform:
     selected_platform = env["p"]

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -89,6 +89,11 @@ const PackedStringArray ProjectSettings::get_required_features() {
 // Returns the features supported by this build of Godot. Includes all required features.
 const PackedStringArray ProjectSettings::_get_supported_features() {
 	PackedStringArray features = get_required_features();
+
+#ifdef LIBRARY_ENABLED
+	features.append("Embedded");
+#endif
+
 #ifdef MODULE_MONO_ENABLED
 	features.append("C#");
 #endif

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -810,9 +810,14 @@ Error GDExtension::open_library(const String &p_path, const String &p_entry_symb
 	}
 
 	GDExtensionInitializationFunction initialization_function = (GDExtensionInitializationFunction)entry_funcptr;
-	GDExtensionBool ret = initialization_function(&gdextension_get_proc_address, this, &initialization);
+	return initialize_extension_function(initialization_function, p_entry_symbol);
+}
 
-	if (ret) {
+Error GDExtension::initialize_extension_function(GDExtensionInitializationFunction initialization_function, const String &p_entry_symbol) {
+	if (library == nullptr) {
+		embedded = true;
+	}
+	if (initialization_function(&gdextension_get_proc_address, this, &initialization)) {
 		level_initialized = -1;
 		return OK;
 	} else {
@@ -823,6 +828,9 @@ Error GDExtension::open_library(const String &p_path, const String &p_entry_symb
 }
 
 void GDExtension::close_library() {
+	if (embedded) {
+		return;
+	}
 	ERR_FAIL_NULL(library);
 	OS::get_singleton()->close_dynamic_library(library);
 
@@ -834,17 +842,21 @@ void GDExtension::close_library() {
 #endif
 }
 
+bool GDExtension::is_embedded() const {
+	return embedded;
+}
+
 bool GDExtension::is_library_open() const {
-	return library != nullptr;
+	return (library != nullptr) || embedded;
 }
 
 GDExtension::InitializationLevel GDExtension::get_minimum_library_initialization_level() const {
-	ERR_FAIL_NULL_V(library, INITIALIZATION_LEVEL_CORE);
+	ERR_FAIL_COND_V(library == nullptr && !embedded, INITIALIZATION_LEVEL_CORE);
 	return InitializationLevel(initialization.minimum_initialization_level);
 }
 
 void GDExtension::initialize_library(InitializationLevel p_level) {
-	ERR_FAIL_NULL(library);
+	ERR_FAIL_COND(library == nullptr && !embedded);
 	ERR_FAIL_COND_MSG(p_level <= int32_t(level_initialized), vformat("Level '%d' must be higher than the current level '%d'", p_level, level_initialized));
 
 	level_initialized = int32_t(p_level);
@@ -854,7 +866,7 @@ void GDExtension::initialize_library(InitializationLevel p_level) {
 	initialization.initialize(initialization.userdata, GDExtensionInitializationLevel(p_level));
 }
 void GDExtension::deinitialize_library(InitializationLevel p_level) {
-	ERR_FAIL_NULL(library);
+	ERR_FAIL_COND(library == nullptr && !embedded);
 	ERR_FAIL_COND(p_level > int32_t(level_initialized));
 
 	level_initialized = int32_t(p_level) - 1;

--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -46,6 +46,7 @@ class GDExtension : public Resource {
 
 	friend class GDExtensionManager;
 
+	bool embedded = false;
 	void *library = nullptr; // pointer if valid,
 	String library_path;
 	bool reloadable = false;
@@ -127,6 +128,7 @@ public:
 	static String find_extension_library(const String &p_path, Ref<ConfigFile> p_config, std::function<bool(String)> p_has_feature, PackedStringArray *r_tags = nullptr);
 	static Vector<SharedObject> find_extension_dependencies(const String &p_path, Ref<ConfigFile> p_config, std::function<bool(String)> p_has_feature);
 
+	Error initialize_extension_function(GDExtensionInitializationFunction initialization_function, const String &p_entry_symbol);
 	Error open_library(const String &p_path, const String &p_entry_symbol, Vector<SharedObject> *p_dependencies = nullptr);
 	void close_library();
 
@@ -137,6 +139,7 @@ public:
 		INITIALIZATION_LEVEL_EDITOR = GDEXTENSION_INITIALIZATION_EDITOR
 	};
 
+	bool is_embedded() const;
 	bool is_library_open() const;
 
 #ifdef TOOLS_ENABLED

--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -33,6 +33,7 @@
 #include "core/config/engine.h"
 #include "core/extension/gdextension.h"
 #include "core/extension/gdextension_compat_hashes.h"
+#include "core/extension/godot_runtime_api.h"
 #include "core/io/file_access.h"
 #include "core/io/xml_parser.h"
 #include "core/object/class_db.h"
@@ -1504,6 +1505,20 @@ static void *gdextension_classdb_get_class_tag(GDExtensionConstStringNamePtr p_c
 	return class_info ? class_info->class_ptr : nullptr;
 }
 
+GDExtensionObjectPtr gdextension_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
+#ifdef LIBRARY_ENABLED
+	return create_godot_instance(p_argc, p_argv, p_init_func);
+#else
+	return nullptr;
+#endif
+}
+
+static void gdextension_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+#ifdef LIBRARY_ENABLED
+	destroy_godot_instance(p_godot_instance);
+#endif
+}
+
 static void gdextension_editor_add_plugin(GDExtensionConstStringNamePtr p_classname) {
 #ifdef TOOLS_ENABLED
 	const StringName classname = *reinterpret_cast<const StringName *>(p_classname);
@@ -1684,6 +1699,8 @@ void gdextension_setup_interface() {
 	REGISTER_INTERFACE_FUNC(editor_remove_plugin);
 	REGISTER_INTERFACE_FUNC(editor_help_load_xml_from_utf8_chars);
 	REGISTER_INTERFACE_FUNC(editor_help_load_xml_from_utf8_chars_and_len);
+	REGISTER_INTERFACE_FUNC(create_godot_instance);
+	REGISTER_INTERFACE_FUNC(destroy_godot_instance);
 }
 
 #undef REGISTER_INTERFACE_FUNCTION

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -2892,6 +2892,14 @@ typedef void (*GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8Chars)(const char *
  */
 typedef void (*GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8CharsAndLen)(const char *p_data, GDExtensionInt p_size);
 
+typedef GDExtensionObjectPtr (*GDExtensionInterfaceCreateGodotInstance)(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func);
+typedef void (*GDExtensionInterfaceDestroyGodotInstance)(GDExtensionObjectPtr p_godot_instance);
+
+#if defined(_WIN32)
+__declspec(dllexport)
+#endif
+		GDExtensionObjectPtr gdextension_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func);
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/extension/gdextension_manager.cpp
+++ b/core/extension/gdextension_manager.cpp
@@ -225,7 +225,7 @@ void GDExtensionManager::_reload_all_scripts() {
 }
 #endif // TOOLS_ENABLED
 
-void GDExtensionManager::load_extensions() {
+void GDExtensionManager::load_extensions(GDExtensionInitializationFunction p_init_func) {
 	Ref<FileAccess> f = FileAccess::open(GDExtension::get_extension_list_config_file(), FileAccess::READ);
 	while (f.is_valid() && !f->eof_reached()) {
 		String s = f->get_line().strip_edges();
@@ -236,6 +236,18 @@ void GDExtensionManager::load_extensions() {
 	}
 
 	OS::get_singleton()->load_platform_gdextensions();
+
+	if (p_init_func) {
+		Ref<GDExtension> libgodot;
+		libgodot.instantiate();
+		Error err = libgodot->initialize_extension_function(p_init_func, "lib_godot");
+		if (err != OK) {
+			ERR_PRINT("Error initializing extension function");
+		} else {
+			libgodot->set_path("res://__LibGodot");
+			GDExtensionManager::get_singleton()->load_extension("res://__LibGodot");
+		}
+	}
 }
 
 void GDExtensionManager::reload_extensions() {

--- a/core/extension/gdextension_manager.h
+++ b/core/extension/gdextension_manager.h
@@ -82,7 +82,7 @@ public:
 
 	static GDExtensionManager *get_singleton();
 
-	void load_extensions();
+	void load_extensions(GDExtensionInitializationFunction p_init_func = nullptr);
 	void reload_extensions();
 
 	GDExtensionManager();

--- a/core/extension/godot_instance.cpp
+++ b/core/extension/godot_instance.cpp
@@ -1,0 +1,69 @@
+/**************************************************************************/
+/*  godot_instance.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "godot_instance.h"
+#include "main/main.h"
+#include "servers/display_server.h"
+
+void GodotInstance::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("start"), &GodotInstance::start);
+	ClassDB::bind_method(D_METHOD("is_started"), &GodotInstance::is_started);
+	ClassDB::bind_method(D_METHOD("iteration"), &GodotInstance::iteration);
+	ClassDB::bind_method(D_METHOD("shutdown"), &GodotInstance::shutdown);
+}
+
+GodotInstance::GodotInstance() {
+}
+
+GodotInstance::~GodotInstance() {
+}
+
+bool GodotInstance::start() {
+	Error err = Main::setup2();
+	if (err != OK) {
+		return false;
+	}
+	started = Main::start() == EXIT_SUCCESS;
+	return started;
+}
+
+bool GodotInstance::is_started() {
+	return started;
+}
+
+bool GodotInstance::iteration() {
+	DisplayServer::get_singleton()->process_events();
+	return Main::iteration();
+}
+
+void GodotInstance::shutdown() {
+	started = false;
+	Main::cleanup();
+}

--- a/core/extension/godot_instance.h
+++ b/core/extension/godot_instance.h
@@ -1,0 +1,55 @@
+/**************************************************************************/
+/*  godot_instance.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef GODOT_INSTANCE_H
+#define GODOT_INSTANCE_H
+
+#include "core/error/error_list.h"
+#include "core/object/class_db.h"
+#include "core/object/object.h"
+
+class GodotInstance : public Object {
+	GDCLASS(GodotInstance, Object);
+
+	static void _bind_methods();
+
+	bool started = false;
+
+public:
+	GodotInstance();
+	~GodotInstance();
+
+	virtual bool start();
+	virtual bool is_started();
+	virtual bool iteration();
+	virtual void shutdown();
+};
+
+#endif // GODOT_INSTANCE_H

--- a/core/extension/godot_runtime_api.h
+++ b/core/extension/godot_runtime_api.h
@@ -1,0 +1,40 @@
+/**************************************************************************/
+/*  godot_runtime_api.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef GODOT_RUNTIME_API_H
+#define GODOT_RUNTIME_API_H
+
+#include "core/extension/gdextension_interface.h"
+
+GDExtensionObjectPtr create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func);
+
+void destroy_godot_instance(GDExtensionObjectPtr p_godot_instance);
+
+#endif // GODOT_RUNTIME_API_H

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -40,6 +40,7 @@
 #include "core/debugger/engine_profiler.h"
 #include "core/extension/gdextension.h"
 #include "core/extension/gdextension_manager.h"
+#include "core/extension/godot_instance.h"
 #include "core/input/input.h"
 #include "core/input/input_map.h"
 #include "core/input/shortcut.h"
@@ -266,6 +267,7 @@ void register_core_types() {
 	GDREGISTER_ABSTRACT_CLASS(ResourceImporter);
 
 	GDREGISTER_CLASS(GDExtension);
+	GDREGISTER_CLASS(GodotInstance);
 
 	GDREGISTER_ABSTRACT_CLASS(GDExtensionManager);
 
@@ -354,12 +356,12 @@ void register_core_singletons() {
 	OS::get_singleton()->benchmark_end_measure("Core", "Register Singletons");
 }
 
-void register_core_extensions() {
+void register_core_extensions(GDExtensionInitializationFunction p_init_func) {
 	OS::get_singleton()->benchmark_begin_measure("Core", "Register Extensions");
 
 	// Hardcoded for now.
 	GDExtension::initialize_gdextensions();
-	gdextension_manager->load_extensions();
+	gdextension_manager->load_extensions(p_init_func);
 	gdextension_manager->initialize_extensions(GDExtension::INITIALIZATION_LEVEL_CORE);
 	_is_core_extensions_registered = true;
 

--- a/core/register_core_types.h
+++ b/core/register_core_types.h
@@ -31,9 +31,11 @@
 #ifndef REGISTER_CORE_TYPES_H
 #define REGISTER_CORE_TYPES_H
 
+#include "core/extension/gdextension_interface.h"
+
 void register_core_types();
 void register_core_settings();
-void register_core_extensions();
+void register_core_extensions(GDExtensionInitializationFunction p_init_func = nullptr);
 void register_core_singletons();
 void unregister_core_types();
 void unregister_core_extensions();

--- a/core/variant/native_ptr.h
+++ b/core/variant/native_ptr.h
@@ -32,6 +32,7 @@
 #define NATIVE_PTR_H
 
 #include "core/math/audio_frame.h"
+#include "core/variant/binder_common.h"
 #include "core/variant/method_ptrcall.h"
 #include "core/variant/type_info.h"
 

--- a/doc/classes/DisplayServerEmbedded.xml
+++ b/doc/classes/DisplayServerEmbedded.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="DisplayServerEmbedded" inherits="DisplayServer" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="resize_window">
+			<return type="void" />
+			<param index="0" name="size" type="Vector2i" />
+			<param index="1" name="id" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="set_content_scale">
+			<return type="void" />
+			<param index="0" name="content_scale" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="set_native_surface" qualifiers="static">
+			<return type="void" />
+			<param index="0" name="native_surface" type="RenderingNativeSurface" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/GodotInstance.xml
+++ b/doc/classes/GodotInstance.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GodotInstance" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="is_started">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="iteration">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="shutdown">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+		<method name="start">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/RenderingNativeSurface.xml
+++ b/doc/classes/RenderingNativeSurface.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="RenderingNativeSurface" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/RenderingNativeSurfaceApple.xml
+++ b/doc/classes/RenderingNativeSurfaceApple.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="RenderingNativeSurfaceApple" inherits="RenderingNativeSurface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="create" qualifiers="static">
+			<return type="RenderingNativeSurfaceApple" />
+			<param index="0" name="layer" type="int" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/RenderingNativeSurfaceVulkan.xml
+++ b/doc/classes/RenderingNativeSurfaceVulkan.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="RenderingNativeSurfaceVulkan" inherits="RenderingNativeSurface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="create" qualifiers="static">
+			<return type="RenderingNativeSurfaceVulkan" />
+			<param index="0" name="vulkan_surface" type="const void*" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -531,6 +531,13 @@
 				Sets layout direction and text writing direction. Right-to-left layouts are necessary for certain languages (e.g. Arabic and Hebrew).
 			</description>
 		</method>
+		<method name="set_native_surface">
+			<return type="void" />
+			<param index="0" name="native_surface" type="RenderingNativeSurface" />
+			<description>
+				Set the native surface of a window.
+			</description>
+		</method>
 		<method name="set_unparent_when_invisible">
 			<return type="void" />
 			<param index="0" name="unparent" type="bool" />

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -25,6 +25,7 @@ SConscript("coremidi/SCsub")
 SConscript("winmidi/SCsub")
 
 # Graphics drivers
+SConscript("apple/SCsub")
 if env["vulkan"]:
     SConscript("vulkan/SCsub")
 if env["d3d12"]:

--- a/drivers/apple/SCsub
+++ b/drivers/apple/SCsub
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+Import("env")
+
+# Driver source files
+env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/apple/rendering_native_surface_apple.cpp
+++ b/drivers/apple/rendering_native_surface_apple.cpp
@@ -1,0 +1,62 @@
+/**************************************************************************/
+/*  rendering_native_surface_apple.cpp                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "rendering_native_surface_apple.h"
+#include "drivers/vulkan/rendering_context_driver_vulkan_moltenvk.h"
+
+void RenderingNativeSurfaceApple::_bind_methods() {
+	ClassDB::bind_static_method("RenderingNativeSurfaceApple", D_METHOD("create", "layer"), &RenderingNativeSurfaceApple::create_api);
+}
+
+Ref<RenderingNativeSurfaceApple> RenderingNativeSurfaceApple::create_api(/* GDExtensionConstPtr<const void> */ uint64_t p_layer) {
+	return RenderingNativeSurfaceApple::create((void *)p_layer /* .operator const void *() */);
+}
+
+Ref<RenderingNativeSurfaceApple> RenderingNativeSurfaceApple::create(void *p_layer) {
+	Ref<RenderingNativeSurfaceApple> result = memnew(RenderingNativeSurfaceApple);
+	result->layer = p_layer;
+	return result;
+}
+
+RenderingContextDriver *RenderingNativeSurfaceApple::create_rendering_context() {
+#ifdef __APPLE__
+	return memnew(RenderingContextDriverVulkanMoltenVk);
+#else
+	return nullptr;
+#endif
+}
+
+RenderingNativeSurfaceApple::RenderingNativeSurfaceApple() {
+	// Does nothing.
+}
+
+RenderingNativeSurfaceApple::~RenderingNativeSurfaceApple() {
+	// Does nothing.
+}

--- a/drivers/apple/rendering_native_surface_apple.h
+++ b/drivers/apple/rendering_native_surface_apple.h
@@ -1,0 +1,60 @@
+/**************************************************************************/
+/*  rendering_native_surface_apple.h                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef RENDERING_NATIVE_SURFACE_APPLE_H
+#define RENDERING_NATIVE_SURFACE_APPLE_H
+
+#include "core/variant/native_ptr.h"
+#include "servers/rendering/rendering_native_surface.h"
+
+class RenderingNativeSurfaceApple : public RenderingNativeSurface {
+	GDCLASS(RenderingNativeSurfaceApple, RenderingNativeSurface);
+
+	static void _bind_methods();
+
+	void *layer = nullptr;
+
+public:
+	// TODO: Remove workaround when SwiftGodot starts to support const void * arguments.
+	static Ref<RenderingNativeSurfaceApple> create_api(/* GDExtensionConstPtr<const void> */ uint64_t p_layer);
+
+	static Ref<RenderingNativeSurfaceApple> create(void *p_layer);
+
+	void *get_metal_layer() const {
+		return layer;
+	};
+
+	RenderingContextDriver *create_rendering_context() override;
+
+	RenderingNativeSurfaceApple();
+	~RenderingNativeSurfaceApple();
+};
+
+#endif // RENDERING_NATIVE_SURFACE_APPLE_H

--- a/drivers/d3d12/rendering_context_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_context_driver_d3d12.cpp
@@ -35,6 +35,7 @@
 #include "core/string/ustring.h"
 #include "core/templates/local_vector.h"
 #include "core/version.h"
+#include "platform/windows/rendering_native_surface_windows.h"
 #include "servers/rendering/rendering_device.h"
 
 #if defined(__GNUC__) && !defined(__clang__)
@@ -244,10 +245,11 @@ void RenderingContextDriverD3D12::driver_free(RenderingDeviceDriver *p_driver) {
 	memdelete(p_driver);
 }
 
-RenderingContextDriver::SurfaceID RenderingContextDriverD3D12::surface_create(const void *p_platform_data) {
-	const WindowPlatformData *wpd = (const WindowPlatformData *)(p_platform_data);
+RenderingContextDriver::SurfaceID RenderingContextDriverD3D12::surface_create(Ref<RenderingNativeSurface> p_native_surface) {
+	Ref<RenderingNativeSurfaceWindows> windows_native_surface = p_native_surface;
+	ERR_FAIL_COND_V(windows_native_surface.is_null(), SurfaceID());
 	Surface *surface = memnew(Surface);
-	surface->hwnd = wpd->window;
+	surface->hwnd = windows_native_surface->get_window_handle();
 	return SurfaceID(surface);
 }
 

--- a/drivers/d3d12/rendering_context_driver_d3d12.h
+++ b/drivers/d3d12/rendering_context_driver_d3d12.h
@@ -82,7 +82,7 @@ public:
 	virtual bool device_supports_present(uint32_t p_device_index, SurfaceID p_surface) const override;
 	virtual RenderingDeviceDriver *driver_create() override;
 	virtual void driver_free(RenderingDeviceDriver *p_driver) override;
-	virtual SurfaceID surface_create(const void *p_platform_data) override;
+	virtual SurfaceID surface_create(Ref<RenderingNativeSurface> p_native_surface) override;
 	virtual void surface_set_size(SurfaceID p_surface, uint32_t p_width, uint32_t p_height) override;
 	virtual void surface_set_vsync_mode(SurfaceID p_surface, DisplayServer::VSyncMode p_vsync_mode) override;
 	virtual DisplayServer::VSyncMode surface_get_vsync_mode(SurfaceID p_surface) const override;
@@ -92,11 +92,6 @@ public:
 	virtual bool surface_get_needs_resize(SurfaceID p_surface) const override;
 	virtual void surface_destroy(SurfaceID p_surface) override;
 	virtual bool is_debug_utils_enabled() const override;
-
-	// Platform-specific data for the Windows embedded in this driver.
-	struct WindowPlatformData {
-		HWND window;
-	};
 
 	// D3D12-only methods.
 	struct Surface {

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -1846,7 +1846,7 @@ void RenderingDeviceDriverD3D12::command_pipeline_barrier(
 		CommandBufferID p_cmd_buffer,
 		BitField<RDD::PipelineStageBits> p_src_stages,
 		BitField<RDD::PipelineStageBits> p_dst_stages,
-		VectorView<RDD::MemoryBarrier> p_memory_barriers,
+		VectorView<RDD::MemoryAccessBarrier> p_memory_barriers,
 		VectorView<RDD::BufferBarrier> p_buffer_barriers,
 		VectorView<RDD::TextureBarrier> p_texture_barriers) {
 	if (p_src_stages.has_flag(PIPELINE_STAGE_ALL_COMMANDS_BIT) && p_dst_stages.has_flag(PIPELINE_STAGE_ALL_COMMANDS_BIT)) {

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -369,7 +369,7 @@ public:
 			CommandBufferID p_cmd_buffer,
 			BitField<RDD::PipelineStageBits> p_src_stages,
 			BitField<RDD::PipelineStageBits> p_dst_stages,
-			VectorView<RDD::MemoryBarrier> p_memory_barriers,
+			VectorView<RDD::MemoryAccessBarrier> p_memory_barriers,
 			VectorView<RDD::BufferBarrier> p_buffer_barriers,
 			VectorView<RDD::TextureBarrier> p_texture_barriers) override final;
 

--- a/drivers/register_driver_types.cpp
+++ b/drivers/register_driver_types.cpp
@@ -31,13 +31,22 @@
 #include "register_driver_types.h"
 
 #include "core/extension/gdextension_manager.h"
+#include "core/object/class_db.h"
 #include "drivers/png/image_loader_png.h"
 #include "drivers/png/resource_saver_png.h"
+
+#include "drivers/apple/rendering_native_surface_apple.h"
+#include "drivers/vulkan/rendering_native_surface_vulkan.h"
 
 static Ref<ImageLoaderPNG> image_loader_png;
 static Ref<ResourceSaverPNG> resource_saver_png;
 
 void register_core_driver_types() {
+	GDREGISTER_ABSTRACT_CLASS(RenderingNativeSurfaceApple)
+#ifdef VULKAN_ENABLED
+	GDREGISTER_ABSTRACT_CLASS(RenderingNativeSurfaceVulkan)
+#endif
+
 	image_loader_png.instantiate();
 	ImageLoader::add_image_format_loader(image_loader_png);
 

--- a/drivers/vulkan/rendering_context_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_context_driver_vulkan.cpp
@@ -31,6 +31,7 @@
 #ifdef VULKAN_ENABLED
 
 #include "rendering_context_driver_vulkan.h"
+#include "rendering_native_surface_vulkan.h"
 
 #include "vk_enum_string_helper.h"
 
@@ -597,9 +598,13 @@ void RenderingContextDriverVulkan::driver_free(RenderingDeviceDriver *p_driver) 
 	memdelete(p_driver);
 }
 
-RenderingContextDriver::SurfaceID RenderingContextDriverVulkan::surface_create(const void *p_platform_data) {
-	DEV_ASSERT(false && "Surface creation should not be called on the platform-agnostic version of the driver.");
-	return SurfaceID();
+RenderingContextDriver::SurfaceID RenderingContextDriverVulkan::surface_create(Ref<RenderingNativeSurface> p_native_surface) {
+	Ref<RenderingNativeSurfaceVulkan> vulkan_native_surface = Object::cast_to<RenderingNativeSurfaceVulkan>(*p_native_surface);
+	ERR_FAIL_COND_V(vulkan_native_surface == nullptr, SurfaceID());
+
+	Surface *surface = memnew(Surface);
+	surface->vk_surface = vulkan_native_surface->get_vulkan_surface();
+	return SurfaceID(surface);
 }
 
 void RenderingContextDriverVulkan::surface_set_size(SurfaceID p_surface, uint32_t p_width, uint32_t p_height) {

--- a/drivers/vulkan/rendering_context_driver_vulkan.h
+++ b/drivers/vulkan/rendering_context_driver_vulkan.h
@@ -125,7 +125,7 @@ public:
 	virtual bool device_supports_present(uint32_t p_device_index, SurfaceID p_surface) const override;
 	virtual RenderingDeviceDriver *driver_create() override;
 	virtual void driver_free(RenderingDeviceDriver *p_driver) override;
-	virtual SurfaceID surface_create(const void *p_platform_data) override;
+	virtual SurfaceID surface_create(Ref<RenderingNativeSurface> p_native_surface) override;
 	virtual void surface_set_size(SurfaceID p_surface, uint32_t p_width, uint32_t p_height) override;
 	virtual void surface_set_vsync_mode(SurfaceID p_surface, DisplayServer::VSyncMode p_vsync_mode) override;
 	virtual DisplayServer::VSyncMode surface_get_vsync_mode(SurfaceID p_surface) const override;

--- a/drivers/vulkan/rendering_context_driver_vulkan_moltenvk.cpp
+++ b/drivers/vulkan/rendering_context_driver_vulkan_moltenvk.cpp
@@ -1,0 +1,75 @@
+/**************************************************************************/
+/*  rendering_context_driver_vulkan_moltenvk.cpp                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "rendering_context_driver_vulkan_moltenvk.h"
+#include "drivers/apple/rendering_native_surface_apple.h"
+#include "rendering_native_surface_vulkan.h"
+
+#ifdef __APPLE__
+#ifdef VULKAN_ENABLED
+
+#ifdef USE_VOLK
+#include <volk.h>
+#else
+#include <vulkan/vulkan_metal.h>
+#endif
+
+const char *RenderingContextDriverVulkanMoltenVk::_get_platform_surface_extension() const {
+	return VK_EXT_METAL_SURFACE_EXTENSION_NAME;
+}
+
+RenderingContextDriver::SurfaceID RenderingContextDriverVulkanMoltenVk::surface_create(Ref<RenderingNativeSurface> p_native_surface) {
+	Ref<RenderingNativeSurfaceApple> apple_native_surface = Object::cast_to<RenderingNativeSurfaceApple>(*p_native_surface);
+	ERR_FAIL_COND_V(apple_native_surface.is_null(), SurfaceID());
+
+	VkMetalSurfaceCreateInfoEXT create_info = {};
+	create_info.sType = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT;
+	create_info.pLayer = apple_native_surface->get_metal_layer();
+
+	VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
+	VkResult err = vkCreateMetalSurfaceEXT(instance_get(), &create_info, nullptr, &vk_surface);
+	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
+
+	Ref<RenderingNativeSurfaceVulkan> vulkan_native_surface = RenderingNativeSurfaceVulkan::create(vk_surface);
+	RenderingContextDriver::SurfaceID result = RenderingContextDriverVulkan::surface_create(vulkan_native_surface);
+
+	return result;
+}
+
+RenderingContextDriverVulkanMoltenVk::RenderingContextDriverVulkanMoltenVk() {
+	// Does nothing.
+}
+
+RenderingContextDriverVulkanMoltenVk::~RenderingContextDriverVulkanMoltenVk() {
+	// Does nothing.
+}
+
+#endif // VULKAN_ENABLED
+#endif // __APPLE__

--- a/drivers/vulkan/rendering_context_driver_vulkan_moltenvk.h
+++ b/drivers/vulkan/rendering_context_driver_vulkan_moltenvk.h
@@ -1,0 +1,60 @@
+/**************************************************************************/
+/*  rendering_context_driver_vulkan_moltenvk.h                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef RENDERING_CONTEXT_DRIVER_VULKAN_MOLTENVK_H
+#define RENDERING_CONTEXT_DRIVER_VULKAN_MOLTENVK_H
+
+#ifdef __APPLE__
+#ifdef VULKAN_ENABLED
+
+#include "drivers/vulkan/rendering_context_driver_vulkan.h"
+
+#ifdef __OBJC__
+@class CAMetalLayer;
+#else
+typedef void CAMetalLayer;
+#endif
+
+class RenderingContextDriverVulkanMoltenVk : public RenderingContextDriverVulkan {
+private:
+	virtual const char *_get_platform_surface_extension() const override final;
+
+protected:
+	SurfaceID surface_create(Ref<RenderingNativeSurface> p_native_surface) override final;
+
+public:
+	RenderingContextDriverVulkanMoltenVk();
+	~RenderingContextDriverVulkanMoltenVk();
+};
+
+#endif // VULKAN_ENABLED
+#endif // __APPLE__
+
+#endif // RENDERING_CONTEXT_DRIVER_VULKAN_MOLTENVK_H

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -1922,7 +1922,7 @@ void RenderingDeviceDriverVulkan::command_pipeline_barrier(
 		CommandBufferID p_cmd_buffer,
 		BitField<PipelineStageBits> p_src_stages,
 		BitField<PipelineStageBits> p_dst_stages,
-		VectorView<MemoryBarrier> p_memory_barriers,
+		VectorView<MemoryAccessBarrier> p_memory_barriers,
 		VectorView<BufferBarrier> p_buffer_barriers,
 		VectorView<TextureBarrier> p_texture_barriers) {
 	VkMemoryBarrier *vk_memory_barriers = ALLOCA_ARRAY(VkMemoryBarrier, p_memory_barriers.size());

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -241,7 +241,7 @@ public:
 			CommandBufferID p_cmd_buffer,
 			BitField<PipelineStageBits> p_src_stages,
 			BitField<PipelineStageBits> p_dst_stages,
-			VectorView<MemoryBarrier> p_memory_barriers,
+			VectorView<MemoryAccessBarrier> p_memory_barriers,
 			VectorView<BufferBarrier> p_buffer_barriers,
 			VectorView<TextureBarrier> p_texture_barriers) override final;
 

--- a/drivers/vulkan/rendering_native_surface_vulkan.cpp
+++ b/drivers/vulkan/rendering_native_surface_vulkan.cpp
@@ -1,0 +1,71 @@
+/**************************************************************************/
+/*  rendering_native_surface_vulkan.cpp                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "rendering_native_surface_vulkan.h"
+
+#include "drivers/vulkan/rendering_context_driver_vulkan.h"
+
+void RenderingNativeSurfaceVulkan::_bind_methods() {
+	ClassDB::bind_static_method("RenderingNativeSurfaceVulkan", D_METHOD("create", "vulkan_surface"), &RenderingNativeSurfaceVulkan::create_api);
+}
+
+Ref<RenderingNativeSurfaceVulkan> RenderingNativeSurfaceVulkan::create_api(GDExtensionConstPtr<const void> p_vulkan_surface) {
+	Ref<RenderingNativeSurfaceVulkan> result = nullptr;
+#ifdef VULKAN_ENABLED
+	result = RenderingNativeSurfaceVulkan::create((VkSurfaceKHR)p_vulkan_surface.operator const void *());
+#endif
+	return result;
+}
+
+#ifdef VULKAN_ENABLED
+
+Ref<RenderingNativeSurfaceVulkan> RenderingNativeSurfaceVulkan::create(VkSurfaceKHR p_vulkan_surface) {
+	Ref<RenderingNativeSurfaceVulkan> result = memnew(RenderingNativeSurfaceVulkan);
+	result->vulkan_surface = p_vulkan_surface;
+	return result;
+}
+
+#endif
+
+RenderingContextDriver *RenderingNativeSurfaceVulkan::create_rendering_context() {
+#if defined(VULKAN_ENABLED)
+	return memnew(RenderingContextDriverVulkan);
+#else
+	return nullptr;
+#endif
+}
+
+RenderingNativeSurfaceVulkan::RenderingNativeSurfaceVulkan() {
+	// Does nothing.
+}
+
+RenderingNativeSurfaceVulkan::~RenderingNativeSurfaceVulkan() {
+	// Does nothing.
+}

--- a/drivers/vulkan/rendering_native_surface_vulkan.h
+++ b/drivers/vulkan/rendering_native_surface_vulkan.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  rendering_context_driver_vulkan_ios.h                                 */
+/*  rendering_native_surface_vulkan.h                                     */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,31 +28,44 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef RENDERING_CONTEXT_DRIVER_VULKAN_IOS_H
-#define RENDERING_CONTEXT_DRIVER_VULKAN_IOS_H
+#ifndef RENDERING_NATIVE_SURFACE_VULKAN_H
+#define RENDERING_NATIVE_SURFACE_VULKAN_H
+
+#include "core/variant/native_ptr.h"
+#include "servers/rendering/rendering_native_surface.h"
 
 #ifdef VULKAN_ENABLED
+#ifdef USE_VOLK
+#include <volk.h>
+#else
+#include <vulkan/vulkan.h>
+#endif
+#endif
 
-#include "drivers/vulkan/rendering_context_driver_vulkan.h"
+class RenderingNativeSurfaceVulkan : public RenderingNativeSurface {
+	GDCLASS(RenderingNativeSurfaceVulkan, RenderingNativeSurface);
 
-#import <QuartzCore/CAMetalLayer.h>
+	static void _bind_methods();
 
-class RenderingContextDriverVulkanIOS : public RenderingContextDriverVulkan {
-private:
-	virtual const char *_get_platform_surface_extension() const override final;
-
-protected:
-	SurfaceID surface_create(const void *p_platform_data) override final;
+#ifdef VULKAN_ENABLED
+	VkSurfaceKHR vulkan_surface = VK_NULL_HANDLE;
+#endif
 
 public:
-	struct WindowPlatformData {
-		CAMetalLayer *const *layer_ptr;
-	};
+	static Ref<RenderingNativeSurfaceVulkan> create_api(GDExtensionConstPtr<const void> vulkan_surface);
 
-	RenderingContextDriverVulkanIOS();
-	~RenderingContextDriverVulkanIOS();
+#ifdef VULKAN_ENABLED
+	static Ref<RenderingNativeSurfaceVulkan> create(VkSurfaceKHR vulkan_surface);
+
+	VkSurfaceKHR get_vulkan_surface() const {
+		return vulkan_surface;
+	};
+#endif
+
+	RenderingContextDriver *create_rendering_context() override;
+
+	RenderingNativeSurfaceVulkan();
+	~RenderingNativeSurfaceVulkan();
 };
 
-#endif // VULKAN_ENABLED
-
-#endif // RENDERING_CONTEXT_DRIVER_VULKAN_IOS_H
+#endif // RENDERING_NATIVE_SURFACE_VULKAN_H

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -734,6 +734,7 @@ Error Main::test_setup() {
 
 	ClassDB::set_current_api(ClassDB::API_CORE);
 #endif
+	register_core_platform_apis();
 	register_platform_apis();
 
 	// Theme needs modules to be initialized so that sub-resources can be loaded.
@@ -795,6 +796,7 @@ void Main::test_cleanup() {
 	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_SCENE);
 
 	unregister_platform_apis();
+	unregister_core_platform_apis();
 	unregister_driver_types();
 	unregister_scene_types();
 
@@ -805,6 +807,7 @@ void Main::test_cleanup() {
 	GDExtensionManager::get_singleton()->deinitialize_extensions(GDExtension::INITIALIZATION_LEVEL_SERVERS);
 	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
 	unregister_server_types();
+	unregister_core_server_types();
 
 	EngineDebugger::deinitialize();
 	OS::get_singleton()->finalize();
@@ -890,7 +893,7 @@ int Main::test_entrypoint(int argc, char *argv[], bool &tests_need_run) {
  *   in help, it's a bit messy and should be globalized with the setup() parsing somehow.
  */
 
-Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_phase) {
+Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_phase, GDExtensionInitializationFunction p_init_func) {
 	Thread::make_main_thread();
 	set_current_thread_safe_for_nodes(true);
 
@@ -908,6 +911,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	register_core_types();
 	register_core_driver_types();
+
+	register_core_platform_apis();
 
 	MAIN_PRINT("Main: Initialize Globals");
 
@@ -1793,7 +1798,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	OS::get_singleton()->ensure_user_data_dir();
 
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
-	register_core_extensions(); // core extensions must be registered after globals setup and before display
+	register_core_extensions(p_init_func); // core extensions must be registered after globals setup and before display
 
 	ResourceUID::get_singleton()->load_from_cache(true); // load UUIDs from cache.
 
@@ -2424,6 +2429,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	message_queue = memnew(MessageQueue);
 
+	// Register Core Server Types
+	register_core_server_types();
+
 	Thread::release_main_thread(); // If setup2() is called from another thread, that one will become main thread, so preventively release this one.
 	set_current_thread_safe_for_nodes(false);
 
@@ -2473,6 +2481,7 @@ error:
 		memdelete(packed_data);
 	}
 
+	unregister_core_platform_apis();
 	unregister_core_driver_types();
 	unregister_core_extensions();
 	unregister_core_types();
@@ -4244,6 +4253,7 @@ void Main::cleanup(bool p_force) {
 	GDExtensionManager::get_singleton()->deinitialize_extensions(GDExtension::INITIALIZATION_LEVEL_SERVERS);
 	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
 	unregister_server_types();
+	unregister_core_server_types();
 
 	EngineDebugger::deinitialize();
 

--- a/main/main.h
+++ b/main/main.h
@@ -32,6 +32,7 @@
 #define MAIN_H
 
 #include "core/error/error_list.h"
+#include "core/extension/gdextension_interface.h"
 #include "core/os/thread.h"
 #include "core/typedefs.h"
 
@@ -71,7 +72,7 @@ public:
 #endif
 
 	static int test_entrypoint(int argc, char *argv[], bool &tests_need_run);
-	static Error setup(const char *execpath, int argc, char *argv[], bool p_second_phase = true);
+	static Error setup(const char *execpath, int argc, char *argv[], bool p_second_phase = true, GDExtensionInitializationFunction p_init_func = nullptr);
 	static Error setup2(); // The thread calling setup2() will effectively become the main thread.
 	static String get_rendering_driver_name();
 #ifdef TESTS_ENABLED

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -60,5 +60,37 @@ env.add_source_files(env.platform_sources, register_platform_apis)
 for platform in env.platform_apis:
     env.add_source_files(env.platform_sources, f"{platform}/api/api.cpp")
 
+# Register core platform APIs
+def register_core_platform_apis_builder(target, source, env):
+    platforms = source[0].read()
+    for p in platforms:
+        api_inc = f'#include "{p}/api/api.h"'
+        api_reg = f"\tregister_core_{p}_api();"
+        api_unreg = f"\tunregister_core_{p}_api();"
+        with methods.generated_wrapper(target) as file:
+            file.write(
+                f"""\
+{api_inc}
+
+void register_core_platform_apis() {{
+{api_reg}
+}}
+
+void unregister_core_platform_apis() {{
+{api_unreg}
+}}
+"""
+            )
+
+
+
+register_core_platform_apis = env.CommandNoCache(
+    "register_core_platform_apis.gen.cpp", env.Value(env.platform_apis), env.Run(register_core_platform_apis_builder)
+)
+env.add_source_files(env.platform_sources, register_core_platform_apis)
+for core in env.platform_apis:
+    env.add_source_files(env.platform_sources, f"{core}/api/api.cpp")
+
 lib = env.add_library("platform", env.platform_sources)
+
 env.Prepend(LIBS=[lib])

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -26,6 +26,7 @@ android_files = [
     "display_server_android.cpp",
     "plugin/godot_plugin_jni.cpp",
     "rendering_context_driver_vulkan_android.cpp",
+    "rendering_native_surface_android.cpp",
 ]
 
 env_android = env.Clone()

--- a/platform/android/api/api.cpp
+++ b/platform/android/api/api.cpp
@@ -34,10 +34,20 @@
 #include "jni_singleton.h"
 
 #include "core/config/engine.h"
+#include "platform/android/rendering_native_surface_android.h"
 
 #if !defined(ANDROID_ENABLED)
 static JavaClassWrapper *java_class_wrapper = nullptr;
 #endif
+
+void register_core_android_api() {
+#if defined(ANDROID_ENABLED)
+	GDREGISTER_ABSTRACT_CLASS(RenderingNativeSurfaceAndroid);
+#endif
+}
+
+void unregister_core_android_api() {
+}
 
 void register_android_api() {
 #if !defined(ANDROID_ENABLED)

--- a/platform/android/api/api.h
+++ b/platform/android/api/api.h
@@ -31,6 +31,8 @@
 #ifndef ANDROID_API_H
 #define ANDROID_API_H
 
+void register_core_android_api();
+void unregister_core_android_api();
 void register_android_api();
 void unregister_android_api();
 

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -36,14 +36,11 @@
 #include "tts_android.h"
 
 #include "core/config/project_settings.h"
+#include "platform/android/rendering_native_surface_android.h"
 
 #if defined(RD_ENABLED)
 #include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
 #include "servers/rendering/rendering_device.h"
-
-#if defined(VULKAN_ENABLED)
-#include "rendering_context_driver_vulkan_android.h"
-#endif
 #endif
 
 #ifdef GLES3_ENABLED
@@ -542,20 +539,16 @@ void DisplayServerAndroid::reset_window() {
 		VSyncMode last_vsync_mode = rendering_context->window_get_vsync_mode(MAIN_WINDOW_ID);
 		rendering_context->window_destroy(MAIN_WINDOW_ID);
 
-		union {
-#ifdef VULKAN_ENABLED
-			RenderingContextDriverVulkanAndroid::WindowPlatformData vulkan;
-#endif
-		} wpd;
+		Ref<RenderingNativeSurfaceAndroid> android_surface;
 #ifdef VULKAN_ENABLED
 		if (rendering_driver == "vulkan") {
 			ANativeWindow *native_window = OS_Android::get_singleton()->get_native_window();
 			ERR_FAIL_NULL(native_window);
-			wpd.vulkan.window = native_window;
+			android_surface = RenderingNativeSurfaceAndroid::create(native_window);
 		}
 #endif
 
-		if (rendering_context->window_create(MAIN_WINDOW_ID, &wpd) != OK) {
+		if (rendering_context->window_create(MAIN_WINDOW_ID, android_surface) != OK) {
 			ERR_PRINT(vformat("Failed to reset %s window.", rendering_driver));
 			memdelete(rendering_context);
 			rendering_context = nullptr;
@@ -596,11 +589,18 @@ DisplayServerAndroid::DisplayServerAndroid(const String &p_rendering_driver, Dis
 	rendering_context = nullptr;
 	rendering_device = nullptr;
 
-#if defined(VULKAN_ENABLED)
+	Ref<RenderingNativeSurfaceAndroid> android_surface;
+#ifdef VULKAN_ENABLED
 	if (rendering_driver == "vulkan") {
-		rendering_context = memnew(RenderingContextDriverVulkanAndroid);
+		ANativeWindow *native_window = OS_Android::get_singleton()->get_native_window();
+		ERR_FAIL_NULL(native_window);
+		android_surface = RenderingNativeSurfaceAndroid::create(native_window);
 	}
 #endif
+
+	if (android_surface.is_valid()) {
+		rendering_context = android_surface->create_rendering_context();
+	}
 
 	if (rendering_context) {
 		if (rendering_context->initialize() != OK) {
@@ -610,20 +610,7 @@ DisplayServerAndroid::DisplayServerAndroid(const String &p_rendering_driver, Dis
 			return;
 		}
 
-		union {
-#ifdef VULKAN_ENABLED
-			RenderingContextDriverVulkanAndroid::WindowPlatformData vulkan;
-#endif
-		} wpd;
-#ifdef VULKAN_ENABLED
-		if (rendering_driver == "vulkan") {
-			ANativeWindow *native_window = OS_Android::get_singleton()->get_native_window();
-			ERR_FAIL_NULL(native_window);
-			wpd.vulkan.window = native_window;
-		}
-#endif
-
-		if (rendering_context->window_create(MAIN_WINDOW_ID, &wpd) != OK) {
+		if (rendering_context->window_create(MAIN_WINDOW_ID, android_surface) != OK) {
 			ERR_PRINT(vformat("Failed to create %s window.", rendering_driver));
 			memdelete(rendering_context);
 			rendering_context = nullptr;

--- a/platform/android/rendering_context_driver_vulkan_android.cpp
+++ b/platform/android/rendering_context_driver_vulkan_android.cpp
@@ -29,6 +29,8 @@
 /**************************************************************************/
 
 #include "rendering_context_driver_vulkan_android.h"
+#include "drivers/vulkan/rendering_native_surface_vulkan.h"
+#include "rendering_native_surface_android.h"
 
 #ifdef VULKAN_ENABLED
 
@@ -42,20 +44,22 @@ const char *RenderingContextDriverVulkanAndroid::_get_platform_surface_extension
 	return VK_KHR_ANDROID_SURFACE_EXTENSION_NAME;
 }
 
-RenderingContextDriver::SurfaceID RenderingContextDriverVulkanAndroid::surface_create(const void *p_platform_data) {
-	const WindowPlatformData *wpd = (const WindowPlatformData *)(p_platform_data);
+RenderingContextDriver::SurfaceID RenderingContextDriverVulkanAndroid::surface_create(Ref<RenderingNativeSurface> p_native_surface) {
+	Ref<RenderingNativeSurfaceAndroid> android_native_surface = Object::cast_to<RenderingNativeSurfaceAndroid>(*p_native_surface);
+	ERR_FAIL_COND_V(android_native_surface.is_null(), SurfaceID());
 
 	VkAndroidSurfaceCreateInfoKHR create_info = {};
 	create_info.sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR;
-	create_info.window = wpd->window;
+	create_info.window = android_native_surface->get_window();
 
 	VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
 	VkResult err = vkCreateAndroidSurfaceKHR(instance_get(), &create_info, nullptr, &vk_surface);
 	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
 
-	Surface *surface = memnew(Surface);
-	surface->vk_surface = vk_surface;
-	return SurfaceID(surface);
+	Ref<RenderingNativeSurfaceVulkan> vulkan_surface = RenderingNativeSurfaceVulkan::create(vk_surface);
+	RenderingContextDriver::SurfaceID result = RenderingContextDriverVulkan::surface_create(vulkan_surface);
+	vulkan_surface.unref();
+	return result;
 }
 
 bool RenderingContextDriverVulkanAndroid::_use_validation_layers() const {

--- a/platform/android/rendering_context_driver_vulkan_android.h
+++ b/platform/android/rendering_context_driver_vulkan_android.h
@@ -42,14 +42,10 @@ private:
 	virtual const char *_get_platform_surface_extension() const override final;
 
 protected:
-	SurfaceID surface_create(const void *p_platform_data) override final;
+	SurfaceID surface_create(Ref<RenderingNativeSurface> p_native_surface) override final;
 	bool _use_validation_layers() const override final;
 
 public:
-	struct WindowPlatformData {
-		ANativeWindow *window;
-	};
-
 	RenderingContextDriverVulkanAndroid() = default;
 	~RenderingContextDriverVulkanAndroid() override = default;
 };

--- a/platform/android/rendering_native_surface_android.cpp
+++ b/platform/android/rendering_native_surface_android.cpp
@@ -1,0 +1,65 @@
+/**************************************************************************/
+/*  rendering_native_surface_android.cpp                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "rendering_native_surface_android.h"
+
+#if defined(VULKAN_ENABLED)
+#include "rendering_context_driver_vulkan_android.h"
+#endif
+
+void RenderingNativeSurfaceAndroid::_bind_methods() {
+	ClassDB::bind_static_method("RenderingNativeSurfaceAndroid", D_METHOD("create", "window"), &RenderingNativeSurfaceAndroid::create_api);
+}
+
+Ref<RenderingNativeSurfaceAndroid> RenderingNativeSurfaceAndroid::create_api(GDExtensionConstPtr<const void> p_window) {
+	return RenderingNativeSurfaceAndroid::create((ANativeWindow *)p_window.operator const void *());
+}
+
+Ref<RenderingNativeSurfaceAndroid> RenderingNativeSurfaceAndroid::create(ANativeWindow *p_window) {
+	Ref<RenderingNativeSurfaceAndroid> result = memnew(RenderingNativeSurfaceAndroid);
+	result->window = p_window;
+	return result;
+}
+
+RenderingContextDriver *RenderingNativeSurfaceAndroid::create_rendering_context() {
+#if defined(VULKAN_ENABLED)
+	return memnew(RenderingContextDriverVulkanAndroid);
+#else
+	return nullptr;
+#endif
+}
+
+RenderingNativeSurfaceAndroid::RenderingNativeSurfaceAndroid() {
+	// Does nothing.
+}
+
+RenderingNativeSurfaceAndroid::~RenderingNativeSurfaceAndroid() {
+	// Does nothing.
+}

--- a/platform/android/rendering_native_surface_android.h
+++ b/platform/android/rendering_native_surface_android.h
@@ -1,0 +1,61 @@
+/**************************************************************************/
+/*  rendering_native_surface_android.h                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef RENDERING_NATIVE_SURFACE_ANDROID_H
+#define RENDERING_NATIVE_SURFACE_ANDROID_H
+
+#include "core/variant/native_ptr.h"
+#include "servers/rendering/rendering_native_surface.h"
+
+struct ANativeWindow;
+
+class RenderingNativeSurfaceAndroid : public RenderingNativeSurface {
+	GDCLASS(RenderingNativeSurfaceAndroid, RenderingNativeSurface);
+
+	static void _bind_methods();
+
+	ANativeWindow *window;
+
+public:
+	static Ref<RenderingNativeSurfaceAndroid> create_api(GDExtensionConstPtr<const void> p_window);
+
+	static Ref<RenderingNativeSurfaceAndroid> create(ANativeWindow *p_window);
+
+	ANativeWindow *get_window() const {
+		return window;
+	};
+
+	RenderingContextDriver *create_rendering_context() override;
+
+	RenderingNativeSurfaceAndroid();
+	~RenderingNativeSurfaceAndroid();
+};
+
+#endif // RENDERING_NATIVE_SURFACE_ANDROID_H

--- a/platform/ios/SCsub
+++ b/platform/ios/SCsub
@@ -58,29 +58,39 @@ def generate_bundle(target, source, env):
     shutil.rmtree(app_dir)
 
 
-ios_lib = [
-    "godot_ios.mm",
+common_ios_lib_files = [
     "os_ios.mm",
-    "main.m",
-    "app_delegate.mm",
-    "view_controller.mm",
     "ios.mm",
-    "rendering_context_driver_vulkan_ios.mm",
-    "display_server_ios.mm",
     "joypad_ios.mm",
-    "godot_view.mm",
-    "tts_ios.mm",
-    "display_layer.mm",
-    "godot_app_delegate.m",
-    "godot_view_renderer.mm",
-    "device_metrics.m",
-    "keyboard_input_view.mm",
-    "key_mapping_ios.mm",
     "ios_terminal_logger.mm",
 ]
 
+ios_lib_files = [
+    "display_server_ios.mm",
+    "display_layer.mm",
+    "device_metrics.m",
+    "app_delegate.mm",
+    "view_controller.mm",
+    "godot_view.mm",
+    "tts_ios.mm",
+    "godot_app_delegate.m",
+    "godot_view_renderer.mm",
+    "keyboard_input_view.mm",
+    "key_mapping_ios.mm",
+    "godot_ios.mm",
+    "main.m",
+]
+
+ios_libgodot_files = [
+    "godot_runtime_api.mm",
+]
+
 env_ios = env.Clone()
-ios_lib = env_ios.add_library("ios", ios_lib)
+
+if env["library_type"] != "executable":
+    ios_lib = env_ios.add_library("ios", common_ios_lib_files + ios_libgodot_files)
+else:
+    ios_lib = env_ios.add_library("ios", common_ios_lib_files + ios_lib_files)
 
 # (iOS) Enable module support
 env_ios.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
@@ -93,7 +103,11 @@ def combine_libs(target=None, source=None, env=None):
     else:
         libtool = "$IOS_TOOLCHAIN_PATH/usr/bin/libtool"
     env.Execute(
-        libtool + ' -static -o "' + lib_path + '" ' + " ".join([('"' + lib.srcnode().abspath + '"') for lib in source])
+        libtool
+        + ' -static -a -o "'
+        + lib_path
+        + '" '
+        + " ".join([('"' + lib.srcnode().abspath + '"') for lib in source])
     )
 
 

--- a/platform/ios/api/api.cpp
+++ b/platform/ios/api/api.cpp
@@ -32,16 +32,28 @@
 
 #if defined(IOS_ENABLED)
 
+void register_core_ios_api() {
+}
+
+void unregister_core_ios_api() {
+}
+
 void register_ios_api() {
+#ifndef IOS_SHARED_LIBRARY_ENABLED
 	godot_ios_plugins_initialize();
+#endif
 }
 
 void unregister_ios_api() {
+#ifndef IOS_SHARED_LIBRARY_ENABLED
 	godot_ios_plugins_deinitialize();
+#endif
 }
 
 #else
 
+void register_core_ios_api() {}
+void unregister_core_ios_api() {}
 void register_ios_api() {}
 void unregister_ios_api() {}
 

--- a/platform/ios/api/api.h
+++ b/platform/ios/api/api.h
@@ -36,6 +36,8 @@ extern void godot_ios_plugins_initialize();
 extern void godot_ios_plugins_deinitialize();
 #endif
 
+void register_core_ios_api();
+void unregister_core_ios_api();
 void register_ios_api();
 void unregister_ios_api();
 

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -154,6 +154,9 @@ def configure(env: "SConsEnvironment"):
     env.Prepend(CPPPATH=["#platform/ios"])
     env.Append(CPPDEFINES=["IOS_ENABLED", "UNIX_ENABLED", "COREAUDIO_ENABLED"])
 
+    if env["library_type"] == "shared_library":
+        env.Append(CPPDEFINES=["IOS_SHARED_LIBRARY_ENABLED"])
+
     if env["vulkan"]:
         env.Append(CPPDEFINES=["VULKAN_ENABLED", "RD_ENABLED"])
 

--- a/platform/ios/display_server_ios.h
+++ b/platform/ios/display_server_ios.h
@@ -39,7 +39,6 @@
 #include "servers/rendering/rendering_device.h"
 
 #if defined(VULKAN_ENABLED)
-#import "rendering_context_driver_vulkan_ios.h"
 
 #ifdef USE_VOLK
 #include <volk.h>

--- a/platform/ios/display_server_ios.mm
+++ b/platform/ios/display_server_ios.mm
@@ -42,6 +42,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/file_access_pack.h"
+#include "drivers/apple/rendering_native_surface_apple.h"
 
 #import <sys/utsname.h>
 
@@ -69,11 +70,7 @@ DisplayServerIOS::DisplayServerIOS(const String &p_rendering_driver, WindowMode 
 
 	CALayer *layer = nullptr;
 
-	union {
-#ifdef VULKAN_ENABLED
-		RenderingContextDriverVulkanIOS::WindowPlatformData vulkan;
-#endif
-	} wpd;
+	Ref<RenderingNativeSurfaceApple> apple_surface;
 
 #if defined(VULKAN_ENABLED)
 	if (rendering_driver == "vulkan") {
@@ -81,8 +78,8 @@ DisplayServerIOS::DisplayServerIOS(const String &p_rendering_driver, WindowMode 
 		if (!layer) {
 			ERR_FAIL_MSG("Failed to create iOS Vulkan rendering layer.");
 		}
-		wpd.vulkan.layer_ptr = (CAMetalLayer *const *)&layer;
-		rendering_context = memnew(RenderingContextDriverVulkanIOS);
+		apple_surface = RenderingNativeSurfaceApple::create((__bridge void *)layer);
+		rendering_context = apple_surface->create_rendering_context();
 	}
 #endif
 
@@ -94,7 +91,7 @@ DisplayServerIOS::DisplayServerIOS(const String &p_rendering_driver, WindowMode 
 			return;
 		}
 
-		if (rendering_context->window_create(MAIN_WINDOW_ID, &wpd) != OK) {
+		if (rendering_context->window_create(MAIN_WINDOW_ID, apple_surface) != OK) {
 			ERR_PRINT(vformat("Failed to create %s window.", rendering_driver));
 			memdelete(rendering_context);
 			rendering_context = nullptr;

--- a/platform/ios/godot_runtime_api.mm
+++ b/platform/ios/godot_runtime_api.mm
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  rendering_context_driver_vulkan_macos.mm                              */
+/*  godot_runtime_api.mm                                                  */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,42 +28,28 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "rendering_context_driver_vulkan_macos.h"
+#include "core/extension/godot_runtime_api.h"
 
-#ifdef VULKAN_ENABLED
+#include "core/extension/godot_instance.h"
+#include "main/main.h"
 
-#ifdef USE_VOLK
-#include <volk.h>
-#else
-#include <vulkan/vulkan_metal.h>
-#endif
+#import "os_ios.h"
 
-const char *RenderingContextDriverVulkanMacOS::_get_platform_surface_extension() const {
-	return VK_EXT_METAL_SURFACE_EXTENSION_NAME;
+static OS_IOS *os = nullptr;
+
+GDExtensionObjectPtr create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
+	os = new OS_IOS();
+
+	Error err = Main::setup(p_argv[0], p_argc - 1, &p_argv[1], false, p_init_func);
+	if (err != OK) {
+		return nullptr;
+	}
+
+	GodotInstance *godot_instance = memnew(GodotInstance);
+
+	return (GDExtensionObjectPtr)godot_instance;
 }
 
-RenderingContextDriver::SurfaceID RenderingContextDriverVulkanMacOS::surface_create(const void *p_platform_data) {
-	const WindowPlatformData *wpd = (const WindowPlatformData *)(p_platform_data);
-
-	VkMetalSurfaceCreateInfoEXT create_info = {};
-	create_info.sType = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT;
-	create_info.pLayer = *wpd->layer_ptr;
-
-	VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
-	VkResult err = vkCreateMetalSurfaceEXT(instance_get(), &create_info, nullptr, &vk_surface);
-	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
-
-	Surface *surface = memnew(Surface);
-	surface->vk_surface = vk_surface;
-	return SurfaceID(surface);
+void destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	memdelete((GodotInstance *)p_godot_instance);
 }
-
-RenderingContextDriverVulkanMacOS::RenderingContextDriverVulkanMacOS() {
-	// Does nothing.
-}
-
-RenderingContextDriverVulkanMacOS::~RenderingContextDriverVulkanMacOS() {
-	// Does nothing.
-}
-
-#endif // VULKAN_ENABLED

--- a/platform/ios/ios.mm
+++ b/platform/ios/ios.mm
@@ -30,8 +30,10 @@
 
 #import "ios.h"
 
+#ifndef IOS_SHARED_LIBRARY_ENABLED
 #import "app_delegate.h"
 #import "view_controller.h"
+#endif
 
 #import <CoreHaptics/CoreHaptics.h>
 #import <UIKit/UIKit.h>
@@ -159,6 +161,7 @@ void iOS::stop_haptic_engine() {
 }
 
 void iOS::alert(const char *p_alert, const char *p_title) {
+#ifndef IOS_SHARED_LIBRARY_ENABLED
 	NSString *title = [NSString stringWithUTF8String:p_title];
 	NSString *message = [NSString stringWithUTF8String:p_alert];
 
@@ -171,6 +174,7 @@ void iOS::alert(const char *p_alert, const char *p_title) {
 	[alert addAction:button];
 
 	[AppDelegate.viewController presentViewController:alert animated:YES completion:nil];
+#endif
 }
 
 String iOS::get_model() const {

--- a/platform/ios/joypad_ios.mm
+++ b/platform/ios/joypad_ios.mm
@@ -30,7 +30,6 @@
 
 #import "joypad_ios.h"
 
-#import "godot_view.h"
 #import "os_ios.h"
 
 #include "core/config/project_settings.h"

--- a/platform/ios/os_ios.h
+++ b/platform/ios/os_ios.h
@@ -45,7 +45,7 @@
 #include "servers/rendering/rendering_device.h"
 
 #if defined(VULKAN_ENABLED)
-#import "rendering_context_driver_vulkan_ios.h"
+#include "drivers/vulkan/rendering_context_driver_vulkan_moltenvk.h"
 #endif
 #endif
 

--- a/platform/ios/os_ios.mm
+++ b/platform/ios/os_ios.mm
@@ -32,11 +32,14 @@
 
 #ifdef IOS_ENABLED
 
+#import "ios_terminal_logger.h"
+
+#ifndef IOS_SHARED_LIBRARY_ENABLED
 #import "app_delegate.h"
 #import "display_server_ios.h"
 #import "godot_view.h"
-#import "ios_terminal_logger.h"
 #import "view_controller.h"
+#endif
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
@@ -44,6 +47,7 @@
 #include "core/io/file_access_pack.h"
 #include "drivers/unix/syslog_logger.h"
 #include "main/main.h"
+#include "servers/display_server_embedded.h"
 
 #import <AudioToolbox/AudioServices.h>
 #import <CoreText/CoreText.h>
@@ -111,7 +115,10 @@ OS_IOS::OS_IOS() {
 
 	AudioDriverManager::add_driver(&audio_driver);
 
+#ifndef IOS_SHARED_LIBRARY_ENABLED
 	DisplayServerIOS::register_ios_driver();
+#endif
+	DisplayServerEmbedded::register_embedded_driver();
 }
 
 OS_IOS::~OS_IOS() {}
@@ -599,15 +606,19 @@ void OS_IOS::on_focus_out() {
 	if (is_focused) {
 		is_focused = false;
 
+#ifndef IOS_SHARED_LIBRARY_ENABLED
 		if (DisplayServerIOS::get_singleton()) {
 			DisplayServerIOS::get_singleton()->send_window_event(DisplayServer::WINDOW_EVENT_FOCUS_OUT);
 		}
+#endif
 
 		if (OS::get_singleton()->get_main_loop()) {
 			OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_OUT);
 		}
 
+#ifndef IOS_SHARED_LIBRARY_ENABLED
 		[AppDelegate.viewController.godotView stopRendering];
+#endif
 
 		audio_driver.stop();
 	}
@@ -617,15 +628,19 @@ void OS_IOS::on_focus_in() {
 	if (!is_focused) {
 		is_focused = true;
 
+#ifndef IOS_SHARED_LIBRARY_ENABLED
 		if (DisplayServerIOS::get_singleton()) {
 			DisplayServerIOS::get_singleton()->send_window_event(DisplayServer::WINDOW_EVENT_FOCUS_IN);
 		}
+#endif
 
 		if (OS::get_singleton()->get_main_loop()) {
 			OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_IN);
 		}
 
+#ifndef IOS_SHARED_LIBRARY_ENABLED
 		[AppDelegate.viewController.godotView startRendering];
+#endif
 
 		audio_driver.start();
 	}

--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -12,6 +12,12 @@ common_linuxbsd = [
     "freedesktop_screensaver.cpp",
 ]
 
+libgodot_files = [
+    "godot_runtime_api.cpp",
+]
+
+executable_files = ["godot_linuxbsd.cpp"]
+
 if env["use_sowrap"]:
     common_linuxbsd.append("xkbcommon-so_wrap.c")
 
@@ -38,7 +44,12 @@ if env["dbus"]:
     if env["use_sowrap"]:
         common_linuxbsd.append("dbus-so_wrap.c")
 
-prog = env.add_program("#bin/godot", ["godot_linuxbsd.cpp"] + common_linuxbsd)
+if env["library_type"] == "static_library":
+    prog = env.add_library("#bin/godot", common_linuxbsd + libgodot_files)
+elif env["library_type"] == "shared_library":
+    prog = env.add_shared_library("#bin/godot", common_linuxbsd + libgodot_files)
+else:
+    prog = env.add_program("#bin/godot", common_linuxbsd + executable_files)
 
 if env["debug_symbols"] and env["separate_debug_symbols"]:
     env.AddPostAction(prog, env.Run(platform_linuxbsd_builders.make_debug_linuxbsd))

--- a/platform/linuxbsd/api/api.cpp
+++ b/platform/linuxbsd/api/api.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  rendering_context_driver_vulkan_ios.mm                                */
+/*  api.cpp                                                               */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,42 +28,37 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#import "rendering_context_driver_vulkan_ios.h"
+#include "api.h"
 
-#ifdef VULKAN_ENABLED
+#ifdef LINUXBSD_ENABLED
+#include "core/object/class_db.h"
 
-#ifdef USE_VOLK
-#include <volk.h>
-#else
-#include <vulkan/vulkan_metal.h>
+#ifdef WAYLAND_ENABLED
+#include "platform/linuxbsd/wayland/rendering_native_surface_wayland.h"
 #endif
 
-const char *RenderingContextDriverVulkanIOS::_get_platform_surface_extension() const {
-	return VK_EXT_METAL_SURFACE_EXTENSION_NAME;
+#ifdef X11_ENABLED
+#include "platform/linuxbsd/x11/rendering_native_surface_x11.h"
+#endif
+
+#endif
+
+void register_core_linuxbsd_api() {
+#ifdef LINUXBSD_ENABLED
+#ifdef WAYLAND_ENABLED
+	GDREGISTER_INTERNAL_CLASS(RenderingNativeSurfaceWayland);
+#endif
+#ifdef X11_ENABLED
+	GDREGISTER_INTERNAL_CLASS(RenderingNativeSurfaceX11);
+#endif
+#endif
 }
 
-RenderingContextDriver::SurfaceID RenderingContextDriverVulkanIOS::surface_create(const void *p_platform_data) {
-	const WindowPlatformData *wpd = (const WindowPlatformData *)(p_platform_data);
-
-	VkMetalSurfaceCreateInfoEXT create_info = {};
-	create_info.sType = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT;
-	create_info.pLayer = *wpd->layer_ptr;
-
-	VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
-	VkResult err = vkCreateMetalSurfaceEXT(instance_get(), &create_info, nullptr, &vk_surface);
-	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
-
-	Surface *surface = memnew(Surface);
-	surface->vk_surface = vk_surface;
-	return SurfaceID(surface);
+void unregister_core_linuxbsd_api() {
 }
 
-RenderingContextDriverVulkanIOS::RenderingContextDriverVulkanIOS() {
-	// Does nothing.
+void register_linuxbsd_api() {
 }
 
-RenderingContextDriverVulkanIOS::~RenderingContextDriverVulkanIOS() {
-	// Does nothing.
+void unregister_linuxbsd_api() {
 }
-
-#endif // VULKAN_ENABLED

--- a/platform/linuxbsd/api/api.h
+++ b/platform/linuxbsd/api/api.h
@@ -1,0 +1,39 @@
+/**************************************************************************/
+/*  api.h                                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef LINUXBSD_API_H
+#define LINUXBSD_API_H
+
+void register_core_linuxbsd_api();
+void unregister_core_linuxbsd_api();
+void register_linuxbsd_api();
+void unregister_linuxbsd_api();
+
+#endif // LINUXBSD_API_H

--- a/platform/linuxbsd/godot_runtime_api.cpp
+++ b/platform/linuxbsd/godot_runtime_api.cpp
@@ -1,0 +1,69 @@
+/**************************************************************************/
+/*  godot_runtime_api.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "core/extension/godot_runtime_api.h"
+
+#include "core/extension/godot_instance.h"
+#include "main/main.h"
+
+#include "os_linuxbsd.h"
+
+static OS_LinuxBSD *os = nullptr;
+
+class GodotInstanceLinuxBSD : public GodotInstance {
+public:
+	bool start() override {
+		const bool result = GodotInstance::start();
+		os->get_main_loop()->initialize();
+		return result;
+	}
+
+	void shutdown() override {
+		os->get_main_loop()->finalize();
+		GodotInstance::shutdown();
+	}
+};
+
+GDExtensionObjectPtr create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
+	os = new OS_LinuxBSD();
+
+	Error err = Main::setup(p_argv[0], p_argc - 1, &p_argv[1], false, p_init_func);
+	if (err != OK) {
+		return nullptr;
+	}
+
+	GodotInstance *godot_instance = memnew(GodotInstanceLinuxBSD);
+
+	return (GDExtensionObjectPtr)godot_instance;
+}
+
+void destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	memdelete((GodotInstance *)p_godot_instance);
+}

--- a/platform/linuxbsd/wayland/SCsub
+++ b/platform/linuxbsd/wayland/SCsub
@@ -179,6 +179,7 @@ source_files = [
     "wayland_thread.cpp",
     "key_mapping_xkb.cpp",
     "detect_prime_egl.cpp",
+    "rendering_native_surface_wayland.cpp",
 ]
 
 if env["use_sowrap"]:

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -50,6 +50,8 @@
 #include "wayland/egl_manager_wayland_gles.h"
 #endif
 
+#include "rendering_native_surface_wayland.h"
+
 String DisplayServerWayland::_get_app_id_from_context(Context p_context) {
 	String app_id;
 
@@ -118,7 +120,7 @@ void DisplayServerWayland::_resize_window(const Size2i &p_size) {
 	}
 }
 
-void DisplayServerWayland::_show_window() {
+bool DisplayServerWayland::_show_window() {
 	MutexLock mutex_lock(wayland_thread.mutex);
 
 	WindowData &wd = main_window;
@@ -142,30 +144,41 @@ void DisplayServerWayland::_show_window() {
 		// the only acceptable way of implementing window showing is to move the
 		// graphics context window creation logic here.
 #ifdef RD_ENABLED
+		Ref<RenderingNativeSurfaceWayland> wayland_surface;
+#ifdef VULKAN_ENABLED
+		if (rendering_driver == "vulkan") {
+			wayland_surface = RenderingNativeSurfaceWayland::create(
+					wayland_thread.get_wl_display(),
+					wayland_thread.window_get_wl_surface(wd.id));
+		}
+#endif
+
+#ifdef VULKAN_ENABLED
+		if (wayland_surface.is_valid()) {
+			rendering_context = wayland_surface->create_rendering_context();
+		}
+#endif
+
 		if (rendering_context) {
-			union {
-#ifdef VULKAN_ENABLED
-				RenderingContextDriverVulkanWayland::WindowPlatformData vulkan;
-#endif
-			} wpd;
-#ifdef VULKAN_ENABLED
-			if (rendering_driver == "vulkan") {
-				wpd.vulkan.surface = wayland_thread.window_get_wl_surface(wd.id);
-				wpd.vulkan.display = wayland_thread.get_wl_display();
+			if (rendering_context->initialize() != OK) {
+				ERR_PRINT(vformat("Could not initialize %s", rendering_driver));
+				memdelete(rendering_context);
+				rendering_context = nullptr;
+				return false;
 			}
-#endif
-			Error err = rendering_context->window_create(wd.id, &wpd);
-			ERR_FAIL_COND_MSG(err != OK, vformat("Can't create a %s window", rendering_driver));
+		}
 
-			rendering_context->window_set_size(wd.id, wd.rect.size.width, wd.rect.size.height);
-			rendering_context->window_set_vsync_mode(wd.id, wd.vsync_mode);
+		Error wayland_err = rendering_context->window_create(wd.id, wayland_surface);
+		ERR_FAIL_COND_V_MSG(wayland_err != OK, false, vformat("Can't create a %s window", rendering_driver));
 
-			emulate_vsync = (rendering_context->window_get_vsync_mode(wd.id) == DisplayServer::VSYNC_ENABLED);
+		rendering_context->window_set_size(wd.id, wd.rect.size.width, wd.rect.size.height);
+		rendering_context->window_set_vsync_mode(wd.id, wd.vsync_mode);
 
-			if (emulate_vsync) {
-				print_verbose("VSYNC: manually throttling frames using MAILBOX.");
-				rendering_context->window_set_vsync_mode(wd.id, DisplayServer::VSYNC_MAILBOX);
-			}
+		emulate_vsync = (rendering_context->window_get_vsync_mode(wd.id) == DisplayServer::VSYNC_ENABLED);
+
+		if (emulate_vsync) {
+			print_verbose("VSYNC: manually throttling frames using MAILBOX.");
+			rendering_context->window_set_vsync_mode(wd.id, DisplayServer::VSYNC_MAILBOX);
 		}
 #endif
 
@@ -174,8 +187,8 @@ void DisplayServerWayland::_show_window() {
 			struct wl_surface *wl_surface = wayland_thread.window_get_wl_surface(wd.id);
 			wd.wl_egl_window = wl_egl_window_create(wl_surface, wd.rect.size.width, wd.rect.size.height);
 
-			Error err = egl_manager->window_create(MAIN_WINDOW_ID, wayland_thread.get_wl_display(), wd.wl_egl_window, wd.rect.size.width, wd.rect.size.height);
-			ERR_FAIL_COND_MSG(err == ERR_CANT_CREATE, "Can't show a GLES3 window.");
+			Error egl_err = egl_manager->window_create(MAIN_WINDOW_ID, wayland_thread.get_wl_display(), wd.wl_egl_window, wd.rect.size.width, wd.rect.size.height);
+			ERR_FAIL_COND_V_MSG(egl_err == ERR_CANT_CREATE, false, "Can't show a GLES3 window.");
 
 			window_set_vsync_mode(wd.vsync_mode, MAIN_WINDOW_ID);
 		}
@@ -189,6 +202,8 @@ void DisplayServerWayland::_show_window() {
 
 		wayland_thread.window_set_title(MAIN_WINDOW_ID, wd.title);
 	}
+
+	return true;
 }
 // Interface methods.
 
@@ -1382,7 +1397,10 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Win
 	wd.rect.size = p_resolution;
 	wd.title = "Godot";
 
-	_show_window();
+	if (!_show_window()) {
+		r_error = ERR_CANT_CREATE;
+		ERR_FAIL_MSG("Could not initialize window.");
+	}
 
 #ifdef RD_ENABLED
 	if (rendering_context) {

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -149,7 +149,7 @@ class DisplayServerWayland : public DisplayServer {
 
 	void _resize_window(const Size2i &p_size);
 
-	virtual void _show_window();
+	bool _show_window();
 
 public:
 	virtual bool has_feature(Feature p_feature) const override;

--- a/platform/linuxbsd/wayland/rendering_context_driver_vulkan_wayland.cpp
+++ b/platform/linuxbsd/wayland/rendering_context_driver_vulkan_wayland.cpp
@@ -31,6 +31,8 @@
 #ifdef VULKAN_ENABLED
 
 #include "rendering_context_driver_vulkan_wayland.h"
+#include "drivers/vulkan/rendering_native_surface_vulkan.h"
+#include "rendering_native_surface_wayland.h"
 
 #ifdef USE_VOLK
 #include <volk.h>
@@ -42,21 +44,22 @@ const char *RenderingContextDriverVulkanWayland::_get_platform_surface_extension
 	return VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME;
 }
 
-RenderingContextDriver::SurfaceID RenderingContextDriverVulkanWayland::surface_create(const void *p_platform_data) {
-	const WindowPlatformData *wpd = (const WindowPlatformData *)(p_platform_data);
+RenderingContextDriver::SurfaceID RenderingContextDriverVulkanWayland::surface_create(Ref<RenderingNativeSurface> p_native_surface) {
+	Ref<RenderingNativeSurfaceWayland> wayland_native_surface = Object::cast_to<RenderingNativeSurfaceWayland>(*p_native_surface);
+	ERR_FAIL_COND_V(wayland_native_surface.is_null(), SurfaceID());
 
 	VkWaylandSurfaceCreateInfoKHR create_info = {};
 	create_info.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
-	create_info.display = wpd->display;
-	create_info.surface = wpd->surface;
+	create_info.display = wayland_native_surface->get_display();
+	create_info.surface = wayland_native_surface->get_surface();
 
 	VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
 	VkResult err = vkCreateWaylandSurfaceKHR(instance_get(), &create_info, nullptr, &vk_surface);
 	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
 
-	Surface *surface = memnew(Surface);
-	surface->vk_surface = vk_surface;
-	return SurfaceID(surface);
+	Ref<RenderingNativeSurfaceVulkan> vulkan_surface = RenderingNativeSurfaceVulkan::create(vk_surface);
+	RenderingContextDriver::SurfaceID result = RenderingContextDriverVulkan::surface_create(vulkan_surface);
+	return result;
 }
 
 RenderingContextDriverVulkanWayland::RenderingContextDriverVulkanWayland() {

--- a/platform/linuxbsd/wayland/rendering_context_driver_vulkan_wayland.h
+++ b/platform/linuxbsd/wayland/rendering_context_driver_vulkan_wayland.h
@@ -40,14 +40,9 @@ private:
 	virtual const char *_get_platform_surface_extension() const override final;
 
 protected:
-	SurfaceID surface_create(const void *p_platform_data) override final;
+	SurfaceID surface_create(Ref<RenderingNativeSurface> p_native_surface) override final;
 
 public:
-	struct WindowPlatformData {
-		struct wl_display *display;
-		struct wl_surface *surface;
-	};
-
 	RenderingContextDriverVulkanWayland();
 	~RenderingContextDriverVulkanWayland();
 };

--- a/platform/linuxbsd/wayland/rendering_native_surface_wayland.cpp
+++ b/platform/linuxbsd/wayland/rendering_native_surface_wayland.cpp
@@ -1,0 +1,67 @@
+/**************************************************************************/
+/*  rendering_native_surface_wayland.cpp                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "rendering_native_surface_wayland.h"
+#include "core/object/class_db.h"
+
+#ifdef VULKAN_ENABLED
+#include "wayland/rendering_context_driver_vulkan_wayland.h"
+#endif
+
+void RenderingNativeSurfaceWayland::_bind_methods() {
+	ClassDB::bind_static_method("RenderingNativeSurfaceWayland", D_METHOD("create", "window", "display"), &RenderingNativeSurfaceWayland::create_api);
+}
+
+Ref<RenderingNativeSurfaceWayland> RenderingNativeSurfaceWayland::create_api(GDExtensionConstPtr<const void> p_display, GDExtensionConstPtr<const void> p_surface) {
+	return RenderingNativeSurfaceWayland::create((struct wl_display *)p_display.operator const void *(), (struct wl_surface *)p_surface.operator const void *());
+}
+
+Ref<RenderingNativeSurfaceWayland> RenderingNativeSurfaceWayland::create(struct wl_display *p_display, struct wl_surface *p_surface) {
+	Ref<RenderingNativeSurfaceWayland> result = memnew(RenderingNativeSurfaceWayland);
+	result->surface = p_surface;
+	result->display = p_display;
+	return result;
+}
+
+RenderingContextDriver *RenderingNativeSurfaceWayland::create_rendering_context() {
+#if defined(VULKAN_ENABLED)
+	return memnew(RenderingContextDriverVulkanWayland);
+#else
+	return nullptr;
+#endif
+}
+
+RenderingNativeSurfaceWayland::RenderingNativeSurfaceWayland() {
+	// Does nothing.
+}
+
+RenderingNativeSurfaceWayland::~RenderingNativeSurfaceWayland() {
+	// Does nothing.
+}

--- a/platform/linuxbsd/wayland/rendering_native_surface_wayland.h
+++ b/platform/linuxbsd/wayland/rendering_native_surface_wayland.h
@@ -1,0 +1,64 @@
+/**************************************************************************/
+/*  rendering_native_surface_wayland.h                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef RENDERING_NATIVE_SURFACE_WAYLAND_H
+#define RENDERING_NATIVE_SURFACE_WAYLAND_H
+
+#include "core/variant/native_ptr.h"
+#include "servers/rendering/rendering_native_surface.h"
+
+class RenderingNativeSurfaceWayland : public RenderingNativeSurface {
+	GDCLASS(RenderingNativeSurfaceWayland, RenderingNativeSurface);
+
+	static void _bind_methods();
+
+	struct wl_display *display;
+	struct wl_surface *surface;
+
+public:
+	static Ref<RenderingNativeSurfaceWayland> create_api(GDExtensionConstPtr<const void> p_display, GDExtensionConstPtr<const void> p_surface);
+
+	static Ref<RenderingNativeSurfaceWayland> create(struct wl_display *p_display, wl_surface *p_surface);
+
+	struct wl_display *get_display() const {
+		return display;
+	};
+
+	struct wl_surface *get_surface() const {
+		return surface;
+	};
+
+	RenderingContextDriver *create_rendering_context() override;
+
+	RenderingNativeSurfaceWayland();
+	~RenderingNativeSurfaceWayland();
+};
+
+#endif // RENDERING_NATIVE_SURFACE_WAYLAND_H

--- a/platform/linuxbsd/x11/SCsub
+++ b/platform/linuxbsd/x11/SCsub
@@ -5,6 +5,7 @@ Import("env")
 source_files = [
     "display_server_x11.cpp",
     "key_mapping_x11.cpp",
+    "rendering_native_surface_x11.cpp",
 ]
 
 if env["use_sowrap"]:

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -42,6 +42,8 @@
 #include "drivers/png/png_driver_common.h"
 #include "main/main.h"
 
+#include "rendering_native_surface_x11.h"
+
 #if defined(VULKAN_ENABLED)
 #include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
 #endif
@@ -5634,19 +5636,29 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 		_update_size_hints(id);
 
 #if defined(RD_ENABLED)
-		if (rendering_context) {
-			union {
+		Ref<RenderingNativeSurfaceX11> x11_surface = nullptr;
 #ifdef VULKAN_ENABLED
-				RenderingContextDriverVulkanX11::WindowPlatformData vulkan;
+		if (rendering_driver == "vulkan") {
+			x11_surface = RenderingNativeSurfaceX11::create(wd.x11_window, x11_display);
+		}
 #endif
-			} wpd;
-#ifdef VULKAN_ENABLED
-			if (rendering_driver == "vulkan") {
-				wpd.vulkan.window = wd.x11_window;
-				wpd.vulkan.display = x11_display;
+
+		if (!rendering_context) {
+			if (x11_surface.is_valid()) {
+				rendering_context = x11_surface->create_rendering_context();
 			}
-#endif
-			Error err = rendering_context->window_create(id, &wpd);
+
+			if (rendering_context) {
+				if (rendering_context->initialize() != OK) {
+					memdelete(rendering_context);
+					rendering_context = nullptr;
+					ERR_FAIL_V_MSG(INVALID_WINDOW_ID, vformat("Could not initialize %s", rendering_driver));
+				}
+			}
+		}
+
+		if (rendering_context) {
+			Error err = rendering_context->window_create(id, x11_surface);
 			ERR_FAIL_COND_V_MSG(err != OK, INVALID_WINDOW_ID, vformat("Can't create a %s window", rendering_driver));
 
 			rendering_context->window_set_size(id, win_rect.size.width, win_rect.size.height);
@@ -6052,22 +6064,11 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 
 	bool driver_found = false;
 #if defined(RD_ENABLED)
-#if defined(VULKAN_ENABLED)
+#ifdef VULKAN_ENABLED
 	if (rendering_driver == "vulkan") {
-		rendering_context = memnew(RenderingContextDriverVulkanX11);
-	}
-#endif
-
-	if (rendering_context) {
-		if (rendering_context->initialize() != OK) {
-			ERR_PRINT(vformat("Could not initialize %s", rendering_driver));
-			memdelete(rendering_context);
-			rendering_context = nullptr;
-			r_error = ERR_CANT_CREATE;
-			return;
-		}
 		driver_found = true;
 	}
+#endif
 #endif
 	// Initialize context and rendering device.
 #if defined(GLES3_ENABLED)

--- a/platform/linuxbsd/x11/rendering_context_driver_vulkan_x11.h
+++ b/platform/linuxbsd/x11/rendering_context_driver_vulkan_x11.h
@@ -35,21 +35,14 @@
 
 #include "drivers/vulkan/rendering_context_driver_vulkan.h"
 
-#include <X11/Xlib.h>
-
 class RenderingContextDriverVulkanX11 : public RenderingContextDriverVulkan {
 private:
 	virtual const char *_get_platform_surface_extension() const override final;
 
 protected:
-	SurfaceID surface_create(const void *p_platform_data) override final;
+	SurfaceID surface_create(Ref<RenderingNativeSurface> p_native_surface) override final;
 
 public:
-	struct WindowPlatformData {
-		::Window window;
-		Display *display;
-	};
-
 	RenderingContextDriverVulkanX11();
 	~RenderingContextDriverVulkanX11();
 };

--- a/platform/linuxbsd/x11/rendering_native_surface_x11.cpp
+++ b/platform/linuxbsd/x11/rendering_native_surface_x11.cpp
@@ -1,0 +1,67 @@
+/**************************************************************************/
+/*  rendering_native_surface_x11.cpp                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "rendering_native_surface_x11.h"
+#include "core/object/class_db.h"
+
+#if defined(VULKAN_ENABLED)
+#include "x11/rendering_context_driver_vulkan_x11.h"
+#endif
+
+void RenderingNativeSurfaceX11::_bind_methods() {
+	ClassDB::bind_static_method("RenderingNativeSurfaceX11", D_METHOD("create", "window", "display"), &RenderingNativeSurfaceX11::create_api);
+}
+
+Ref<RenderingNativeSurfaceX11> RenderingNativeSurfaceX11::create_api(GDExtensionConstPtr<const void> p_window, GDExtensionConstPtr<const void> p_display) {
+	return RenderingNativeSurfaceX11::create((::Window)p_window.operator const void *(), (Display *)p_display.operator const void *());
+}
+
+Ref<RenderingNativeSurfaceX11> RenderingNativeSurfaceX11::create(::Window p_window, Display *p_display) {
+	Ref<RenderingNativeSurfaceX11> result = memnew(RenderingNativeSurfaceX11);
+	result->window = p_window;
+	result->display = p_display;
+	return result;
+}
+
+RenderingContextDriver *RenderingNativeSurfaceX11::create_rendering_context() {
+#if defined(VULKAN_ENABLED)
+	return memnew(RenderingContextDriverVulkanX11);
+#else
+	return nullptr;
+#endif
+}
+
+RenderingNativeSurfaceX11::RenderingNativeSurfaceX11() {
+	// Does nothing.
+}
+
+RenderingNativeSurfaceX11::~RenderingNativeSurfaceX11() {
+	// Does nothing.
+}

--- a/platform/linuxbsd/x11/rendering_native_surface_x11.h
+++ b/platform/linuxbsd/x11/rendering_native_surface_x11.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  rendering_context_driver_vulkan_macos.h                               */
+/*  rendering_native_surface_x11.h                                        */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,31 +28,39 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef RENDERING_CONTEXT_DRIVER_VULKAN_MACOS_H
-#define RENDERING_CONTEXT_DRIVER_VULKAN_MACOS_H
+#ifndef RENDERING_NATIVE_SURFACE_X11_H
+#define RENDERING_NATIVE_SURFACE_X11_H
 
-#ifdef VULKAN_ENABLED
+#include "core/variant/native_ptr.h"
+#include "servers/rendering/rendering_native_surface.h"
 
-#include "drivers/vulkan/rendering_context_driver_vulkan.h"
+#include <X11/Xlib.h>
 
-#import <QuartzCore/CAMetalLayer.h>
+class RenderingNativeSurfaceX11 : public RenderingNativeSurface {
+	GDCLASS(RenderingNativeSurfaceX11, RenderingNativeSurface);
 
-class RenderingContextDriverVulkanMacOS : public RenderingContextDriverVulkan {
-private:
-	virtual const char *_get_platform_surface_extension() const override final;
+	static void _bind_methods();
 
-protected:
-	SurfaceID surface_create(const void *p_platform_data) override final;
+	::Window window;
+	Display *display;
 
 public:
-	struct WindowPlatformData {
-		CAMetalLayer *const *layer_ptr;
+	static Ref<RenderingNativeSurfaceX11> create_api(GDExtensionConstPtr<const void> p_window, GDExtensionConstPtr<const void> p_display);
+
+	static Ref<RenderingNativeSurfaceX11> create(::Window p_window, Display *p_display);
+
+	::Window get_window() const {
+		return window;
 	};
 
-	RenderingContextDriverVulkanMacOS();
-	~RenderingContextDriverVulkanMacOS();
+	Display *get_display() const {
+		return display;
+	};
+
+	RenderingContextDriver *create_rendering_context() override;
+
+	RenderingNativeSurfaceX11();
+	~RenderingNativeSurfaceX11();
 };
 
-#endif // VULKAN_ENABLED
-
-#endif // RENDERING_CONTEXT_DRIVER_VULKAN_MACOS_H
+#endif // RENDERING_NATIVE_SURFACE_X11_H

--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -96,7 +96,7 @@ def generate_bundle(target, source, env):
         shutil.rmtree(app_dir)
 
 
-files = [
+common_files = [
     "os_macos.mm",
     "godot_application.mm",
     "godot_application_delegate.mm",
@@ -109,7 +109,6 @@ files = [
     "godot_window_delegate.mm",
     "godot_window.mm",
     "key_mapping_macos.mm",
-    "godot_main_macos.mm",
     "godot_menu_delegate.mm",
     "godot_menu_item.mm",
     "godot_open_save_delegate.mm",
@@ -117,12 +116,24 @@ files = [
     "dir_access_macos.mm",
     "tts_macos.mm",
     "joypad_macos.mm",
-    "rendering_context_driver_vulkan_macos.mm",
     "gl_manager_macos_angle.mm",
     "gl_manager_macos_legacy.mm",
 ]
 
-prog = env.add_program("#bin/godot", files)
+executable_files = [
+    "godot_main_macos.mm",
+]
+
+libgodot_files = [
+    "godot_runtime_api.mm",
+]
+
+if env["library_type"] == "static_library":
+    prog = env.add_library("#bin/godot", common_files + libgodot_files)
+elif env["library_type"] == "shared_library":
+    prog = env.add_shared_library("#bin/godot", common_files + libgodot_files)
+else:
+    prog = env.add_program("#bin/godot", common_files + executable_files)
 
 if env["debug_symbols"] and env["separate_debug_symbols"]:
     env.AddPostAction(prog, env.Run(platform_macos_builders.make_debug_macos))

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -45,7 +45,7 @@
 #include "servers/rendering/rendering_device.h"
 
 #if defined(VULKAN_ENABLED)
-#include "rendering_context_driver_vulkan_macos.h"
+#include "drivers/vulkan/rendering_context_driver_vulkan_moltenvk.h"
 #endif // VULKAN_ENABLED
 #endif // RD_ENABLED
 

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -58,6 +58,8 @@
 #include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
 #endif
 
+#include "drivers/apple/rendering_native_surface_apple.h"
+
 #import <Carbon/Carbon.h>
 #import <Cocoa/Cocoa.h>
 #import <IOKit/IOCFPlugIn.h>
@@ -134,18 +136,30 @@ DisplayServerMacOS::WindowID DisplayServerMacOS::_create_window(WindowMode p_mod
 		}
 
 #if defined(RD_ENABLED)
-		if (rendering_context) {
-			union {
+		Ref<RenderingNativeSurfaceApple> apple_surface;
 #ifdef VULKAN_ENABLED
-				RenderingContextDriverVulkanMacOS::WindowPlatformData vulkan;
+		if (rendering_driver == "vulkan") {
+			apple_surface = RenderingNativeSurfaceApple::create((__bridge void *)layer);
+		}
 #endif
-			} wpd;
-#ifdef VULKAN_ENABLED
-			if (rendering_driver == "vulkan") {
-				wpd.vulkan.layer_ptr = (CAMetalLayer *const *)&layer;
+
+		if (!rendering_context) {
+			if (apple_surface.is_valid()) {
+				rendering_context = apple_surface->create_rendering_context();
 			}
-#endif
-			Error err = rendering_context->window_create(window_id_counter, &wpd);
+
+			if (rendering_context) {
+				if (rendering_context->initialize() != OK) {
+					memdelete(rendering_context);
+					rendering_context = nullptr;
+					ERR_PRINT("Could not initialize " + rendering_driver);
+					return INVALID_WINDOW_ID;
+				}
+			}
+		}
+
+		if (rendering_context) {
+			Error err = rendering_context->window_create(window_id_counter, apple_surface);
 			ERR_FAIL_COND_V_MSG(err != OK, INVALID_WINDOW_ID, vformat("Can't create a %s context", rendering_driver));
 
 			rendering_context->window_set_size(window_id_counter, p_rect.size.width, p_rect.size.height);
@@ -3657,22 +3671,6 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 		}
 	}
 #endif
-#if defined(RD_ENABLED)
-#if defined(VULKAN_ENABLED)
-	if (rendering_driver == "vulkan") {
-		rendering_context = memnew(RenderingContextDriverVulkanMacOS);
-	}
-#endif
-
-	if (rendering_context) {
-		if (rendering_context->initialize() != OK) {
-			memdelete(rendering_context);
-			rendering_context = nullptr;
-			r_error = ERR_CANT_CREATE;
-			ERR_FAIL_MSG("Could not initialize " + rendering_driver);
-		}
-	}
-#endif
 
 	Point2i window_position;
 	if (p_position != nullptr) {
@@ -3686,7 +3684,10 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 	}
 
 	WindowID main_window = _create_window(p_mode, p_vsync_mode, Rect2i(window_position, p_resolution));
-	ERR_FAIL_COND(main_window == INVALID_WINDOW_ID);
+	if (main_window == INVALID_WINDOW_ID) {
+		r_error = ERR_CANT_CREATE;
+		ERR_FAIL_MSG("Could not create main window.");
+	}
 	for (int i = 0; i < WINDOW_FLAG_MAX; i++) {
 		if (p_flags & (1 << i)) {
 			window_set_flag(WindowFlags(i), true, main_window);

--- a/platform/macos/godot_runtime_api.mm
+++ b/platform/macos/godot_runtime_api.mm
@@ -1,0 +1,72 @@
+/**************************************************************************/
+/*  godot_runtime_api.mm                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "core/extension/godot_runtime_api.h"
+
+#include "core/extension/godot_instance.h"
+#include "main/main.h"
+
+#include "os_macos.h"
+
+static OS_MacOS *os = nullptr;
+
+class GodotInstanceMacOS : public GodotInstance {
+public:
+	bool start() override {
+		const bool result = GodotInstance::start();
+		os->get_main_loop()->initialize();
+		return result;
+	}
+
+	void shutdown() override {
+		os->get_main_loop()->finalize();
+		GodotInstance::shutdown();
+	}
+};
+
+GDExtensionObjectPtr create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
+	os = new OS_MacOS();
+
+	Error err;
+	@autoreleasepool {
+		err = Main::setup(p_argv[0], p_argc - 1, &p_argv[1], false, p_init_func);
+	}
+	if (err != OK) {
+		return nullptr;
+	}
+
+	GodotInstance *godot_instance = memnew(GodotInstanceMacOS);
+
+	return (GDExtensionObjectPtr)godot_instance;
+}
+
+void destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	memdelete((GodotInstance *)p_godot_instance);
+}

--- a/platform/register_platform_apis.h
+++ b/platform/register_platform_apis.h
@@ -31,7 +31,9 @@
 #ifndef REGISTER_PLATFORM_APIS_H
 #define REGISTER_PLATFORM_APIS_H
 
+void register_core_platform_apis();
 void register_platform_apis();
+void unregister_core_platform_apis();
 void unregister_platform_apis();
 
 #endif // REGISTER_PLATFORM_APIS_H

--- a/platform/web/api/api.cpp
+++ b/platform/web/api/api.cpp
@@ -37,6 +37,12 @@
 
 static JavaScriptBridge *javascript_bridge_singleton;
 
+void register_core_web_api() {
+}
+
+void unregister_core_web_api() {
+}
+
 void register_web_api() {
 	WebToolsEditorPlugin::initialize();
 	GDREGISTER_ABSTRACT_CLASS(JavaScriptObject);

--- a/platform/web/api/api.h
+++ b/platform/web/api/api.h
@@ -31,6 +31,8 @@
 #ifndef WEB_API_H
 #define WEB_API_H
 
+void register_core_web_api();
+void unregister_core_web_api();
 void register_web_api();
 void unregister_web_api();
 

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -9,7 +9,6 @@ import platform_windows_builders
 sources = []
 
 common_win = [
-    "godot_windows.cpp",
     "os_windows.cpp",
     "display_server_windows.cpp",
     "key_mapping_windows.cpp",
@@ -22,7 +21,14 @@ common_win = [
     "gl_manager_windows_angle.cpp",
     "wgl_detect_version.cpp",
     "rendering_context_driver_vulkan_windows.cpp",
+    "rendering_native_surface_windows.cpp",
 ]
+
+libgodot_files = [
+    "godot_runtime_api.cpp",
+]
+
+executable_files = ["godot_windows.cpp"]
 
 if env.msvc:
     common_win += ["crash_handler_windows_seh.cpp"]
@@ -53,27 +59,36 @@ res_obj = env.RES(res_target, res_file)
 env.add_source_files(sources, common_win)
 sources += res_obj
 
-prog = env.add_program("#bin/godot", sources, PROGSUFFIX=env["PROGSUFFIX"])
-arrange_program_clean(prog)
+if env["library_type"] == "static_library":
+    prog = env.add_library("#bin/godot", sources + libgodot_files, PROGSUFFIX=env["PROGSUFFIX"])
+    arrange_program_clean(prog)
+elif env["library_type"] == "shared_library":
+    prog = env.add_shared_library("#bin/godot", sources + libgodot_files, PROGSUFFIX=env["PROGSUFFIX"])
+    arrange_program_clean(prog)
+else:
+    prog = env.add_program("#bin/godot", sources + executable_files, PROGSUFFIX=env["PROGSUFFIX"])
+    arrange_program_clean(prog)
 
-# Build console wrapper app.
-if env["windows_subsystem"] == "gui":
-    env_wrap = env.Clone()
-    res_wrap_file = "godot_res_wrap.rc"
-    res_wrap_target = "godot_res_wrap" + env["OBJSUFFIX"]
-    res_wrap_obj = env_wrap.RES(res_wrap_target, res_wrap_file)
+    # Build console wrapper app.
+    if env["windows_subsystem"] == "gui":
+        env_wrap = env.Clone()
+        res_wrap_file = "godot_res_wrap.rc"
+        res_wrap_target = "godot_res_wrap" + env["OBJSUFFIX"]
+        res_wrap_obj = env_wrap.RES(res_wrap_target, res_wrap_file)
 
-    if env.msvc:
-        env_wrap.Append(LINKFLAGS=["/SUBSYSTEM:CONSOLE"])
-        env_wrap.Append(LINKFLAGS=["version.lib"])
-    else:
-        env_wrap.Append(LINKFLAGS=["-Wl,--subsystem,console"])
-        env_wrap.Append(LIBS=["version"])
+        if env.msvc:
+            env_wrap.Append(LINKFLAGS=["/SUBSYSTEM:CONSOLE"])
+            env_wrap.Append(LINKFLAGS=["version.lib"])
+        else:
+            env_wrap.Append(LINKFLAGS=["-Wl,--subsystem,console"])
+            env_wrap.Append(LIBS=["version"])
 
-    prog_wrap = env_wrap.add_program("#bin/godot", common_win_wrap + res_wrap_obj, PROGSUFFIX=env["PROGSUFFIX_WRAP"])
-    arrange_program_clean(prog_wrap)
-    env_wrap.Depends(prog_wrap, prog)
-    sources += common_win_wrap + res_wrap_obj
+        prog_wrap = env_wrap.add_program(
+            "#bin/godot", common_win_wrap + res_wrap_obj, PROGSUFFIX=env["PROGSUFFIX_WRAP"]
+        )
+        arrange_program_clean(prog_wrap)
+        env_wrap.Depends(prog_wrap, prog)
+        sources += common_win_wrap + res_wrap_obj
 
 # Microsoft Visual Studio Project Generation
 if env["vsproj"]:

--- a/platform/windows/api/api.cpp
+++ b/platform/windows/api/api.cpp
@@ -1,0 +1,51 @@
+/**************************************************************************/
+/*  api.cpp                                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "api.h"
+
+#ifdef WINDOWS_ENABLED
+#include "core/object/class_db.h"
+#include "platform/windows/rendering_native_surface_windows.h"
+#endif
+
+void register_core_windows_api() {
+#ifdef WINDOWS_ENABLED
+	GDREGISTER_ABSTRACT_CLASS(RenderingNativeSurfaceWindows);
+#endif
+}
+
+void unregister_core_windows_api() {
+}
+
+void register_windows_api() {
+}
+
+void unregister_windows_api() {
+}

--- a/platform/windows/api/api.h
+++ b/platform/windows/api/api.h
@@ -1,0 +1,39 @@
+/**************************************************************************/
+/*  api.h                                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef WINDOWS_API_H
+#define WINDOWS_API_H
+
+void register_core_windows_api();
+void unregister_core_windows_api();
+void register_windows_api();
+void unregister_windows_api();
+
+#endif // WINDOWS_API_H

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -373,7 +373,7 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
     ## Build type
 
     # TODO: Re-evaluate the need for this / streamline with common config.
-    if env["target"] == "template_release":
+    if env["target"] == "template_release" and env["library_type"] == "executable":
         env.Append(LINKFLAGS=["/ENTRY:mainCRTStartup"])
 
     if env["windows_subsystem"] == "gui":

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -38,6 +38,7 @@
 #include "core/version.h"
 #include "drivers/png/png_driver_common.h"
 #include "main/main.h"
+#include "platform/windows/rendering_native_surface_windows.h"
 
 #if defined(VULKAN_ENABLED)
 #include "rendering_context_driver_vulkan_windows.h"
@@ -5184,29 +5185,42 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 		}
 
 #ifdef RD_ENABLED
+		Ref<RenderingNativeSurfaceWindows> windows_surface = nullptr;
+#if defined(VULKAN_ENABLED) || defined(D3D12_ENABLED)
+		if (rendering_driver == "vulkan" || rendering_driver == "d3d12") {
+			windows_surface = RenderingNativeSurfaceWindows::create(wd.hWnd, hInstance);
+		}
+#endif
+
+		if (!rendering_context) {
+			if (windows_surface.is_valid()) {
+#if defined(VULKAN_ENABLED)
+				if (rendering_driver == "vulkan") {
+					windows_surface->set_driver_type(RenderingNativeSurfaceWindows::DriverType::Vulkan);
+				}
+#endif
+#if defined(D3D12_ENABLED)
+				if (rendering_driver == "d3d12") {
+					windows_surface->set_driver_type(RenderingNativeSurfaceWindows::DriverType::D3D12);
+				}
+#endif
+				rendering_context = windows_surface->create_rendering_context();
+			}
+
+			if (rendering_context) {
+				if (rendering_context->initialize() != OK) {
+					memdelete(rendering_context);
+					rendering_context = nullptr;
+					return INVALID_WINDOW_ID;
+				}
+			}
+		}
+
 		if (rendering_context) {
-			union {
-#ifdef VULKAN_ENABLED
-				RenderingContextDriverVulkanWindows::WindowPlatformData vulkan;
-#endif
-#ifdef D3D12_ENABLED
-				RenderingContextDriverD3D12::WindowPlatformData d3d12;
-#endif
-			} wpd;
-#ifdef VULKAN_ENABLED
-			if (rendering_driver == "vulkan") {
-				wpd.vulkan.window = wd.hWnd;
-				wpd.vulkan.instance = hInstance;
-			}
-#endif
-#ifdef D3D12_ENABLED
-			if (rendering_driver == "d3d12") {
-				wpd.d3d12.window = wd.hWnd;
-			}
-#endif
-			if (rendering_context->window_create(id, &wpd) != OK) {
+			if (rendering_context->window_create(id, windows_surface) != OK) {
 				ERR_PRINT(vformat("Failed to create %s window.", rendering_driver));
 				memdelete(rendering_context);
+				windows_surface.unref();
 				rendering_context = nullptr;
 				windows.erase(id);
 				return INVALID_WINDOW_ID;
@@ -5215,6 +5229,7 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 			rendering_context->window_set_size(id, WindowRect.right - WindowRect.left, WindowRect.bottom - WindowRect.top);
 			rendering_context->window_set_vsync_mode(id, p_vsync_mode);
 			wd.context_created = true;
+			windows_surface.unref();
 		}
 #endif
 
@@ -5673,27 +5688,6 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 
 	_register_raw_input_devices(INVALID_WINDOW_ID);
 
-#if defined(RD_ENABLED)
-#if defined(VULKAN_ENABLED)
-	if (rendering_driver == "vulkan") {
-		rendering_context = memnew(RenderingContextDriverVulkanWindows);
-	}
-#endif
-#if defined(D3D12_ENABLED)
-	if (rendering_driver == "d3d12") {
-		rendering_context = memnew(RenderingContextDriverD3D12);
-	}
-#endif
-
-	if (rendering_context) {
-		if (rendering_context->initialize() != OK) {
-			memdelete(rendering_context);
-			rendering_context = nullptr;
-			r_error = ERR_UNAVAILABLE;
-			return;
-		}
-	}
-#endif
 // Init context and rendering device
 #if defined(GLES3_ENABLED)
 
@@ -5795,7 +5789,10 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 	}
 
 	WindowID main_window = _create_window(p_mode, p_vsync_mode, p_flags, Rect2i(window_position, p_resolution));
-	ERR_FAIL_COND_MSG(main_window == INVALID_WINDOW_ID, "Failed to create main window.");
+	if (main_window == INVALID_WINDOW_ID) {
+		r_error = ERR_UNAVAILABLE;
+		ERR_FAIL_MSG("Failed to create main window.");
+	}
 
 	joypad = new JoypadWindows(&windows[MAIN_WINDOW_ID].hWnd);
 

--- a/platform/windows/godot_runtime_api.cpp
+++ b/platform/windows/godot_runtime_api.cpp
@@ -1,0 +1,69 @@
+/**************************************************************************/
+/*  godot_runtime_api.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "core/extension/godot_runtime_api.h"
+
+#include "core/extension/godot_instance.h"
+#include "main/main.h"
+
+#include "os_windows.h"
+
+static OS_Windows *os = nullptr;
+
+class GodotInstanceWindows : public GodotInstance {
+public:
+	bool start() override {
+		const bool result = GodotInstance::start();
+		os->get_main_loop()->initialize();
+		return result;
+	}
+
+	void shutdown() override {
+		os->get_main_loop()->finalize();
+		GodotInstance::shutdown();
+	}
+};
+
+GDExtensionObjectPtr create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func) {
+	os = new OS_Windows(nullptr);
+
+	Error err = Main::setup(p_argv[0], p_argc - 1, &p_argv[1], false, p_init_func);
+	if (err != OK) {
+		return nullptr;
+	}
+
+	GodotInstance *godot_instance = memnew(GodotInstanceWindows);
+
+	return (GDExtensionObjectPtr)godot_instance;
+}
+
+void destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	memdelete((GodotInstance *)p_godot_instance);
+}

--- a/platform/windows/rendering_context_driver_vulkan_windows.cpp
+++ b/platform/windows/rendering_context_driver_vulkan_windows.cpp
@@ -32,6 +32,8 @@
 
 #include "core/os/os.h"
 
+#include "drivers/vulkan/rendering_native_surface_vulkan.h"
+#include "platform/windows/rendering_native_surface_windows.h"
 #include "rendering_context_driver_vulkan_windows.h"
 
 #ifdef USE_VOLK
@@ -55,21 +57,22 @@ RenderingContextDriverVulkanWindows::~RenderingContextDriverVulkanWindows() {
 	// Does nothing.
 }
 
-RenderingContextDriver::SurfaceID RenderingContextDriverVulkanWindows::surface_create(const void *p_platform_data) {
-	const WindowPlatformData *wpd = (const WindowPlatformData *)(p_platform_data);
+RenderingContextDriver::SurfaceID RenderingContextDriverVulkanWindows::surface_create(Ref<RenderingNativeSurface> p_native_surface) {
+	Ref<RenderingNativeSurfaceWindows> windows_native_surface = Object::cast_to<RenderingNativeSurfaceWindows>(*p_native_surface);
+	ERR_FAIL_COND_V(windows_native_surface.is_null(), SurfaceID());
 
 	VkWin32SurfaceCreateInfoKHR create_info = {};
 	create_info.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
-	create_info.hinstance = wpd->instance;
-	create_info.hwnd = wpd->window;
+	create_info.hinstance = windows_native_surface->get_instance();
+	create_info.hwnd = windows_native_surface->get_window_handle();
 
 	VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
 	VkResult err = vkCreateWin32SurfaceKHR(instance_get(), &create_info, nullptr, &vk_surface);
 	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
 
-	Surface *surface = memnew(Surface);
-	surface->vk_surface = vk_surface;
-	return SurfaceID(surface);
+	Ref<RenderingNativeSurfaceVulkan> vulkan_surface = RenderingNativeSurfaceVulkan::create(vk_surface);
+	RenderingContextDriver::SurfaceID result = RenderingContextDriverVulkan::surface_create(vulkan_surface);
+	return result;
 }
 
 #endif // WINDOWS_ENABLED && VULKAN_ENABLED

--- a/platform/windows/rendering_context_driver_vulkan_windows.h
+++ b/platform/windows/rendering_context_driver_vulkan_windows.h
@@ -34,23 +34,16 @@
 #ifdef VULKAN_ENABLED
 
 #include "drivers/vulkan/rendering_context_driver_vulkan.h"
-
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+#include "servers/rendering/rendering_native_surface.h"
 
 class RenderingContextDriverVulkanWindows : public RenderingContextDriverVulkan {
 private:
 	const char *_get_platform_surface_extension() const override final;
 
 protected:
-	SurfaceID surface_create(const void *p_platform_data) override final;
+	SurfaceID surface_create(Ref<RenderingNativeSurface> p_native_surface) override final;
 
 public:
-	struct WindowPlatformData {
-		HWND window;
-		HINSTANCE instance;
-	};
-
 	RenderingContextDriverVulkanWindows();
 	~RenderingContextDriverVulkanWindows() override;
 };

--- a/platform/windows/rendering_native_surface_windows.cpp
+++ b/platform/windows/rendering_native_surface_windows.cpp
@@ -1,0 +1,79 @@
+/**************************************************************************/
+/*  rendering_native_surface_windows.cpp                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "rendering_native_surface_windows.h"
+
+#if defined(VULKAN_ENABLED)
+#include "platform/windows/rendering_context_driver_vulkan_windows.h"
+#endif
+#if defined(D3D12_ENABLED)
+#include "drivers/d3d12/rendering_context_driver_d3d12.h"
+#endif
+
+void RenderingNativeSurfaceWindows::_bind_methods() {
+	ClassDB::bind_static_method("RenderingNativeSurfaceWindows", D_METHOD("create", "hwnd", "instance"), &RenderingNativeSurfaceWindows::create_api);
+}
+
+Ref<RenderingNativeSurfaceWindows> RenderingNativeSurfaceWindows::create_api(GDExtensionConstPtr<const void> p_window, GDExtensionConstPtr<const void> p_instance) {
+	return RenderingNativeSurfaceWindows::create((HWND)p_window.operator const void *(), (HINSTANCE)p_instance.operator const void *());
+}
+
+Ref<RenderingNativeSurfaceWindows> RenderingNativeSurfaceWindows::create(HWND p_window, HINSTANCE p_instance) {
+	Ref<RenderingNativeSurfaceWindows> result = memnew(RenderingNativeSurfaceWindows);
+	result->window = p_window;
+	result->instance = p_instance;
+	return result;
+}
+
+RenderingContextDriver *RenderingNativeSurfaceWindows::create_rendering_context() {
+	switch (driver_type) {
+#if defined(VULKAN_ENABLED)
+		case RenderingNativeSurfaceWindows::DriverType::Vulkan:
+			return memnew(RenderingContextDriverVulkanWindows);
+#endif
+#if defined(D3D12_ENABLED)
+		case RenderingNativeSurfaceWindows::DriverType::D3D12:
+			return memnew(RenderingContextDriverD3D12);
+#else
+		case RenderingNativeSurfaceWindows::DriverType::D3D12:
+			return nullptr;
+#endif
+		default:
+			return nullptr;
+	}
+}
+
+RenderingNativeSurfaceWindows::RenderingNativeSurfaceWindows() {
+	// Does nothing.
+}
+
+RenderingNativeSurfaceWindows::~RenderingNativeSurfaceWindows() {
+	// Does nothing.
+}

--- a/platform/windows/rendering_native_surface_windows.h
+++ b/platform/windows/rendering_native_surface_windows.h
@@ -1,0 +1,82 @@
+/**************************************************************************/
+/*  rendering_native_surface_windows.h                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef RENDERING_NATIVE_SURFACE_WINDOWS_H
+#define RENDERING_NATIVE_SURFACE_WINDOWS_H
+
+#include "core/variant/native_ptr.h"
+#include "servers/rendering/rendering_native_surface.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+class RenderingNativeSurfaceWindows : public RenderingNativeSurface {
+public:
+	enum class DriverType {
+		D3D12,
+		Vulkan
+	};
+
+private:
+	GDCLASS(RenderingNativeSurfaceWindows, RenderingNativeSurface);
+
+	static void _bind_methods();
+
+	HWND window;
+	HINSTANCE instance;
+	DriverType driver_type;
+
+public:
+	static Ref<RenderingNativeSurfaceWindows> create_api(GDExtensionConstPtr<const void> p_window, GDExtensionConstPtr<const void> p_instance);
+	static Ref<RenderingNativeSurfaceWindows> create(HWND p_window, HINSTANCE p_instance);
+
+	HWND get_window_handle() const {
+		return window;
+	};
+
+	HINSTANCE get_instance() const {
+		return instance;
+	};
+
+	void set_driver_type(DriverType p_driver_type) {
+		driver_type = p_driver_type;
+	}
+
+	DriverType get_driver_type() {
+		return driver_type;
+	}
+
+	RenderingContextDriver *create_rendering_context() override;
+
+	RenderingNativeSurfaceWindows();
+	~RenderingNativeSurfaceWindows();
+};
+
+#endif // RENDERING_NATIVE_SURFACE_WINDOWS_H

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -572,6 +572,17 @@ bool Window::is_in_edited_scene_root() const {
 
 void Window::_make_window() {
 	ERR_FAIL_COND(window_id != DisplayServer::INVALID_WINDOW_ID);
+	if (native_surface != nullptr) {
+		window_id = DisplayServer::get_singleton()->create_native_window(native_surface);
+		ERR_FAIL_COND(window_id == DisplayServer::INVALID_WINDOW_ID);
+
+		_update_window_size();
+
+		_update_window_callbacks();
+
+		RS::get_singleton()->viewport_set_update_mode(get_viewport_rid(), RS::VIEWPORT_UPDATE_WHEN_VISIBLE);
+		return;
+	}
 
 	if (transient && transient_to_focused) {
 		_make_transient();
@@ -644,6 +655,13 @@ void Window::_update_from_window() {
 
 void Window::_clear_window() {
 	ERR_FAIL_COND(window_id == DisplayServer::INVALID_WINDOW_ID);
+	if (native_surface != nullptr) {
+		DisplayServer::get_singleton()->delete_native_window(window_id);
+		window_id = DisplayServer::INVALID_WINDOW_ID;
+
+		RS::get_singleton()->viewport_set_update_mode(get_viewport_rid(), RS::VIEWPORT_UPDATE_DISABLED);
+		return;
+	}
 
 	bool had_focus = has_focus();
 
@@ -801,6 +819,11 @@ void Window::hide() {
 
 void Window::set_visible(bool p_visible) {
 	ERR_MAIN_THREAD_GUARD;
+	if (native_surface.is_valid()) {
+		visible = true;
+		return;
+	}
+
 	if (visible == p_visible) {
 		return;
 	}
@@ -866,6 +889,29 @@ void Window::_clear_transient() {
 			transient_parent->exclusive_child = nullptr;
 		}
 		transient_parent = nullptr;
+	}
+}
+
+void Window::set_native_surface(Ref<RenderingNativeSurface> p_native_surface) {
+	Ref<RenderingNativeSurface> new_native_handle = p_native_surface;
+	if (new_native_handle == native_surface) {
+		return;
+	}
+	if (!initialized) {
+		native_surface = new_native_handle;
+		return;
+	}
+	if (embedder) {
+		embedder->_sub_window_remove(this);
+	} else {
+		_clear_window();
+	}
+	native_surface = new_native_handle;
+	embedder = get_embedder();
+	if (embedder) {
+		embedder->_sub_window_register(this);
+	} else {
+		_make_window();
 	}
 }
 
@@ -1228,6 +1274,10 @@ bool Window::get_force_native() const {
 Viewport *Window::get_embedder() const {
 	ERR_READ_THREAD_GUARD_V(nullptr);
 	if (force_native && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_SUBWINDOWS) && !is_in_edited_scene_root()) {
+		return nullptr;
+	}
+
+	if (native_surface != nullptr) {
 		return nullptr;
 	}
 
@@ -2793,6 +2843,8 @@ void Window::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_visible", "visible"), &Window::set_visible);
 	ClassDB::bind_method(D_METHOD("is_visible"), &Window::is_visible);
+
+	ClassDB::bind_method(D_METHOD("set_native_surface", "native_surface"), &Window::set_native_surface);
 
 	ClassDB::bind_method(D_METHOD("hide"), &Window::hide);
 	ClassDB::bind_method(D_METHOD("show"), &Window::show);

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -33,6 +33,7 @@
 
 #include "scene/main/viewport.h"
 #include "scene/resources/theme.h"
+#include "servers/rendering/rendering_native_surface.h"
 
 class Font;
 class Shortcut;
@@ -163,6 +164,8 @@ private:
 	void _propagate_window_notification(Node *p_node, int p_notification);
 
 	void _update_window_callbacks();
+
+	Ref<RenderingNativeSurface> native_surface;
 
 	Window *transient_parent = nullptr;
 	Window *exclusive_child = nullptr;
@@ -312,6 +315,8 @@ public:
 
 	virtual void set_visible(bool p_visible);
 	bool is_visible() const;
+
+	void set_native_surface(Ref<RenderingNativeSurface> p_native_surface);
 
 	void update_mouse_cursor_state() override;
 

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -7,6 +7,7 @@ env.servers_sources = []
 env.add_source_files(env.servers_sources, "audio_server.cpp")
 env.add_source_files(env.servers_sources, "camera_server.cpp")
 env.add_source_files(env.servers_sources, "display_server.cpp")
+env.add_source_files(env.servers_sources, "display_server_embedded.cpp")
 env.add_source_files(env.servers_sources, "navigation_server_2d.cpp")
 env.add_source_files(env.servers_sources, "navigation_server_3d.cpp")
 env.add_source_files(env.servers_sources, "physics_server_2d.cpp")

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -575,6 +575,18 @@ DisplayServer::WindowID DisplayServer::create_sub_window(WindowMode p_mode, VSyn
 	ERR_FAIL_V_MSG(INVALID_WINDOW_ID, "Sub-windows not supported by this display server.");
 }
 
+DisplayServer::WindowID DisplayServer::create_native_window(Ref<RenderingNativeSurface> p_native_window) {
+	ERR_FAIL_V_MSG(INVALID_WINDOW_ID, "Native windows not supported by this display server.");
+}
+
+bool DisplayServer::is_native_window(DisplayServer::WindowID p_id) {
+	ERR_FAIL_V_MSG(false, "Native windows not supported by this display server.");
+}
+
+void DisplayServer::delete_native_window(DisplayServer::WindowID p_id) {
+	ERR_FAIL_MSG("Native windows not supported by this display server.");
+}
+
 void DisplayServer::show_window(WindowID p_id) {
 	ERR_FAIL_MSG("Sub-windows not supported by this display server.");
 }

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -35,8 +35,8 @@
 #include "core/io/resource.h"
 #include "core/os/os.h"
 #include "core/variant/callable.h"
-
 #include "display/native_menu.h"
+#include "servers/rendering/rendering_native_surface.h"
 
 class Texture2D;
 class Image;
@@ -142,6 +142,7 @@ public:
 		FEATURE_NATIVE_HELP,
 		FEATURE_NATIVE_DIALOG_INPUT,
 		FEATURE_NATIVE_DIALOG_FILE,
+		FEATURE_NATIVE_WINDOWS,
 	};
 
 	virtual bool has_feature(Feature p_feature) const = 0;
@@ -391,6 +392,10 @@ public:
 	virtual WindowID create_sub_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect = Rect2i());
 	virtual void show_window(WindowID p_id);
 	virtual void delete_sub_window(WindowID p_id);
+
+	virtual WindowID create_native_window(Ref<RenderingNativeSurface> p_native_window);
+	virtual bool is_native_window(WindowID p_id);
+	virtual void delete_native_window(WindowID p_id);
 
 	virtual WindowID window_get_active_popup() const { return INVALID_WINDOW_ID; };
 	virtual void window_set_popup_safe_rect(WindowID p_window, const Rect2i &p_rect){};

--- a/servers/display_server_embedded.cpp
+++ b/servers/display_server_embedded.cpp
@@ -1,0 +1,498 @@
+/**************************************************************************/
+/*  display_server_embedded.cpp                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "display_server_embedded.h"
+
+#include "core/config/project_settings.h"
+#include "core/io/file_access_pack.h"
+
+#ifdef RD_ENABLED
+#if defined(VULKAN_ENABLED)
+#include "drivers/vulkan/rendering_context_driver_vulkan_moltenvk.h"
+
+#ifdef USE_VOLK
+#include <volk.h>
+#else
+#include <vulkan/vulkan.h>
+#endif
+#endif // VULKAN_ENABLED
+#endif // RD_ENABLED
+
+#include "drivers/apple/rendering_native_surface_apple.h"
+
+Ref<RenderingNativeSurface> DisplayServerEmbedded::native_surface = nullptr;
+
+DisplayServerEmbedded *DisplayServerEmbedded::get_singleton() {
+	return (DisplayServerEmbedded *)DisplayServer::get_singleton();
+}
+
+void DisplayServerEmbedded::set_native_surface(Ref<RenderingNativeSurface> p_native_surface) {
+	native_surface = p_native_surface;
+}
+
+void DisplayServerEmbedded::_bind_methods() {
+	ClassDB::bind_static_method("DisplayServerEmbedded", D_METHOD("set_native_surface", "native_surface"), &DisplayServerEmbedded::set_native_surface);
+	ClassDB::bind_method(D_METHOD("resize_window", "size", "id"), &DisplayServerEmbedded::resize_window);
+	ClassDB::bind_method(D_METHOD("set_content_scale", "content_scale"), &DisplayServerEmbedded::set_content_scale);
+}
+
+DisplayServerEmbedded::DisplayServerEmbedded(const String &p_rendering_driver, WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Error &r_error) {
+	ERR_FAIL_NULL_MSG(native_surface, "Native surface has not been set.");
+
+	rendering_driver = p_rendering_driver;
+
+	native_menu = memnew(NativeMenu);
+
+#if defined(RD_ENABLED)
+	rendering_context = nullptr;
+	rendering_device = nullptr;
+
+#if defined(VULKAN_ENABLED)
+	if (rendering_driver == "vulkan") {
+		rendering_context = native_surface->create_rendering_context();
+	}
+#endif
+
+	if (rendering_context) {
+		if (rendering_context->initialize() != OK) {
+			ERR_PRINT(vformat("Failed to initialize %s context", rendering_driver));
+			memdelete(rendering_context);
+			rendering_context = nullptr;
+			return;
+		}
+
+		if (create_native_window(native_surface) != MAIN_WINDOW_ID) {
+			ERR_PRINT(vformat("Failed to create %s window.", rendering_driver));
+			memdelete(rendering_context);
+			rendering_context = nullptr;
+			r_error = ERR_UNAVAILABLE;
+			return;
+		}
+
+		rendering_device = memnew(RenderingDevice);
+		rendering_device->initialize(rendering_context, MAIN_WINDOW_ID);
+		rendering_device->screen_create(MAIN_WINDOW_ID);
+
+		RendererCompositorRD::make_current();
+	}
+#endif
+
+#if defined(GLES3_ENABLED)
+	if (rendering_driver == "opengl3") {
+		ERR_FAIL_MSG("Embedded OpenGL rendering is not yet supported.");
+	}
+#endif
+
+	Input::get_singleton()->set_event_dispatch_function(_dispatch_input_events);
+
+	r_error = OK;
+}
+
+DisplayServerEmbedded::~DisplayServerEmbedded() {
+	if (native_menu) {
+		memdelete(native_menu);
+		native_menu = nullptr;
+	}
+
+#if defined(RD_ENABLED)
+	if (rendering_device) {
+		rendering_device->screen_free(MAIN_WINDOW_ID);
+		memdelete(rendering_device);
+		rendering_device = nullptr;
+	}
+
+	if (rendering_context) {
+		rendering_context->window_destroy(MAIN_WINDOW_ID);
+		memdelete(rendering_context);
+		rendering_context = nullptr;
+	}
+#endif
+}
+
+DisplayServer *DisplayServerEmbedded::create_func(const String &p_rendering_driver, WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Error &r_error) {
+	return memnew(DisplayServerEmbedded(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_position, p_resolution, p_screen, r_error));
+}
+
+Vector<String> DisplayServerEmbedded::get_rendering_drivers_func() {
+	Vector<String> drivers;
+
+#if defined(VULKAN_ENABLED)
+	drivers.push_back("vulkan");
+#endif
+	//#if defined(GLES3_ENABLED)
+	//	drivers.push_back("opengl3");
+	//#endif
+
+	return drivers;
+}
+
+void DisplayServerEmbedded::register_embedded_driver() {
+	register_create_function("embedded", create_func, get_rendering_drivers_func);
+}
+
+// MARK: Events
+
+void DisplayServerEmbedded::window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window) {
+	window_resize_callbacks[p_window] = p_callable;
+}
+
+void DisplayServerEmbedded::window_set_window_event_callback(const Callable &p_callable, WindowID p_window) {
+	window_event_callbacks[p_window] = p_callable;
+}
+void DisplayServerEmbedded::window_set_input_event_callback(const Callable &p_callable, WindowID p_window) {
+	input_event_callbacks[p_window] = p_callable;
+}
+
+void DisplayServerEmbedded::window_set_input_text_callback(const Callable &p_callable, WindowID p_window) {
+	input_text_callbacks[p_window] = p_callable;
+}
+
+void DisplayServerEmbedded::window_set_drop_files_callback(const Callable &p_callable, WindowID p_window) {
+	// Not supported
+}
+
+void DisplayServerEmbedded::process_events() {
+	Input::get_singleton()->flush_buffered_events();
+}
+
+void DisplayServerEmbedded::_dispatch_input_events(const Ref<InputEvent> &p_event) {
+	DisplayServerEmbedded::get_singleton()->send_input_event(p_event);
+}
+
+void DisplayServerEmbedded::send_input_event(const Ref<InputEvent> &p_event, WindowID p_id) const {
+	_window_callback(input_event_callbacks[p_id], p_event);
+}
+
+void DisplayServerEmbedded::send_input_text(const String &p_text, WindowID p_id) const {
+	_window_callback(input_text_callbacks[p_id], p_text);
+}
+
+void DisplayServerEmbedded::send_window_event(DisplayServer::WindowEvent p_event, WindowID p_id) const {
+	_window_callback(window_event_callbacks[p_id], int(p_event));
+}
+
+void DisplayServerEmbedded::_window_callback(const Callable &p_callable, const Variant &p_arg) const {
+	if (!p_callable.is_null()) {
+		p_callable.call(p_arg);
+	}
+}
+
+// MARK: - Input
+
+// MARK: Touches
+
+void DisplayServerEmbedded::touch_press(int p_idx, int p_x, int p_y, bool p_pressed, bool p_double_click) {
+	Ref<InputEventScreenTouch> ev;
+	ev.instantiate();
+
+	ev->set_index(p_idx);
+	ev->set_pressed(p_pressed);
+	ev->set_position(Vector2(p_x, p_y));
+	ev->set_double_tap(p_double_click);
+	perform_event(ev);
+}
+
+void DisplayServerEmbedded::touch_drag(int p_idx, int p_prev_x, int p_prev_y, int p_x, int p_y, float p_pressure, Vector2 p_tilt) {
+	Ref<InputEventScreenDrag> ev;
+	ev.instantiate();
+	ev->set_index(p_idx);
+	ev->set_pressure(p_pressure);
+	ev->set_tilt(p_tilt);
+	ev->set_position(Vector2(p_x, p_y));
+	ev->set_relative(Vector2(p_x - p_prev_x, p_y - p_prev_y));
+	ev->set_relative_screen_position(ev->get_relative());
+	perform_event(ev);
+}
+
+void DisplayServerEmbedded::perform_event(const Ref<InputEvent> &p_event) {
+	Input::get_singleton()->parse_input_event(p_event);
+}
+
+void DisplayServerEmbedded::touches_canceled(int p_idx) {
+	touch_press(p_idx, -1, -1, false, false);
+}
+
+// MARK: -
+
+bool DisplayServerEmbedded::has_feature(Feature p_feature) const {
+	switch (p_feature) {
+#ifndef DISABLE_DEPRECATED
+		case FEATURE_GLOBAL_MENU: {
+			return (native_menu && native_menu->has_feature(NativeMenu::FEATURE_GLOBAL_MENU));
+		} break;
+#endif
+		// case FEATURE_CURSOR_SHAPE:
+		// case FEATURE_CUSTOM_CURSOR_SHAPE:
+		// case FEATURE_HIDPI:
+		// case FEATURE_ICON:
+		// case FEATURE_IME:
+		// case FEATURE_MOUSE:
+		// case FEATURE_MOUSE_WARP:
+		// case FEATURE_NATIVE_DIALOG:
+		// case FEATURE_NATIVE_ICON:
+		// case FEATURE_WINDOW_TRANSPARENCY:
+		//case FEATURE_CLIPBOARD:
+		//case FEATURE_KEEP_SCREEN_ON:
+		//case FEATURE_ORIENTATION:
+		//case FEATURE_VIRTUAL_KEYBOARD:
+		//case FEATURE_TEXT_TO_SPEECH:
+		case FEATURE_NATIVE_WINDOWS:
+		case FEATURE_TOUCHSCREEN:
+			return true;
+		default:
+			return false;
+	}
+}
+
+String DisplayServerEmbedded::get_name() const {
+	return "embedded";
+}
+
+int DisplayServerEmbedded::get_screen_count() const {
+	return 1;
+}
+
+int DisplayServerEmbedded::get_primary_screen() const {
+	return 0;
+}
+
+Point2i DisplayServerEmbedded::screen_get_position(int p_screen) const {
+	return Size2i();
+}
+
+Size2i DisplayServerEmbedded::screen_get_size(int p_screen) const {
+	return window_get_size(MAIN_WINDOW_ID);
+}
+
+Rect2i DisplayServerEmbedded::screen_get_usable_rect(int p_screen) const {
+	return Rect2i(screen_get_position(p_screen), screen_get_size(p_screen));
+}
+
+int DisplayServerEmbedded::screen_get_dpi(int p_screen) const {
+	return 96;
+}
+
+float DisplayServerEmbedded::screen_get_refresh_rate(int p_screen) const {
+	return -1;
+}
+
+Vector<DisplayServer::WindowID> DisplayServerEmbedded::get_window_list() const {
+	Vector<DisplayServer::WindowID> list;
+	list.push_back(MAIN_WINDOW_ID);
+	return list;
+}
+
+DisplayServer::WindowID DisplayServerEmbedded::get_window_at_screen_position(const Point2i &p_position) const {
+	return MAIN_WINDOW_ID;
+}
+
+DisplayServer::WindowID DisplayServerEmbedded::create_native_window(Ref<RenderingNativeSurface> p_native_surface) {
+#if defined(RD_ENABLED)
+
+	WindowID window_id = window_id_counter++;
+
+	if (rendering_context->window_create(window_id, p_native_surface) != OK) {
+		ERR_PRINT(vformat("Failed to create native window."));
+		return INVALID_WINDOW_ID;
+	}
+
+	if (rendering_device) {
+		rendering_device->screen_create(window_id);
+	}
+	return window_id;
+#else
+	ERR_FAIL_V_MSG(INVALID_WINDOW_ID, "Cannot create native window with current driver.");
+#endif
+}
+
+bool DisplayServerEmbedded::is_native_window(DisplayServer::WindowID p_id) {
+	return true;
+}
+
+void DisplayServerEmbedded::delete_native_window(DisplayServer::WindowID p_id) {
+#if defined(RD_ENABLED)
+	if (rendering_device) {
+		rendering_device->screen_free(p_id);
+	}
+
+	if (rendering_context) {
+		rendering_context->window_destroy(p_id);
+	}
+#endif
+}
+
+int64_t DisplayServerEmbedded::window_get_native_handle(HandleType p_handle_type, WindowID p_window) const {
+	return 0; // Not supported.
+}
+
+void DisplayServerEmbedded::window_attach_instance_id(ObjectID p_instance, WindowID p_window) {
+	window_attached_instance_id = p_instance;
+}
+
+ObjectID DisplayServerEmbedded::window_get_attached_instance_id(WindowID p_window) const {
+	return window_attached_instance_id;
+}
+
+void DisplayServerEmbedded::window_set_title(const String &p_title, WindowID p_window) {
+	// Not supported
+}
+
+int DisplayServerEmbedded::window_get_current_screen(WindowID p_window) const {
+	return SCREEN_OF_MAIN_WINDOW;
+}
+
+void DisplayServerEmbedded::window_set_current_screen(int p_screen, WindowID p_window) {
+	// Not supported
+}
+
+Point2i DisplayServerEmbedded::window_get_position(WindowID p_window) const {
+	return Point2i();
+}
+
+Point2i DisplayServerEmbedded::window_get_position_with_decorations(WindowID p_window) const {
+	return Point2i();
+}
+
+void DisplayServerEmbedded::window_set_position(const Point2i &p_position, WindowID p_window) {
+	// Probably not supported for single window iOS app
+}
+
+void DisplayServerEmbedded::window_set_transient(WindowID p_window, WindowID p_parent) {
+	// Not supported
+}
+
+void DisplayServerEmbedded::window_set_max_size(const Size2i p_size, WindowID p_window) {
+	// Not supported
+}
+
+Size2i DisplayServerEmbedded::window_get_max_size(WindowID p_window) const {
+	return Size2i();
+}
+
+void DisplayServerEmbedded::window_set_min_size(const Size2i p_size, WindowID p_window) {
+	// Not supported
+}
+
+Size2i DisplayServerEmbedded::window_get_min_size(WindowID p_window) const {
+	return Size2i();
+}
+
+void DisplayServerEmbedded::window_set_size(const Size2i p_size, WindowID p_window) {
+	// Not supported
+}
+
+Size2i DisplayServerEmbedded::window_get_size(WindowID p_window) const {
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		uint32_t width = 0;
+		uint32_t height = 0;
+		rendering_context->window_get_size(p_window, width, height);
+		return Size2i(width, height);
+	}
+#endif
+	return Size2i();
+}
+
+Size2i DisplayServerEmbedded::window_get_size_with_decorations(WindowID p_window) const {
+	return window_get_size(p_window);
+}
+
+void DisplayServerEmbedded::window_set_mode(WindowMode p_mode, WindowID p_window) {
+	// Not supported
+}
+
+DisplayServer::WindowMode DisplayServerEmbedded::window_get_mode(WindowID p_window) const {
+	return WindowMode::WINDOW_MODE_FULLSCREEN;
+}
+
+bool DisplayServerEmbedded::window_is_maximize_allowed(WindowID p_window) const {
+	return false;
+}
+
+void DisplayServerEmbedded::window_set_flag(WindowFlags p_flag, bool p_enabled, WindowID p_window) {
+	// Not supported
+}
+
+bool DisplayServerEmbedded::window_get_flag(WindowFlags p_flag, WindowID p_window) const {
+	return false;
+}
+
+void DisplayServerEmbedded::window_request_attention(WindowID p_window) {
+	// Not supported
+}
+
+void DisplayServerEmbedded::window_move_to_foreground(WindowID p_window) {
+	// Not supported
+}
+
+bool DisplayServerEmbedded::window_is_focused(WindowID p_window) const {
+	return true;
+}
+
+float DisplayServerEmbedded::screen_get_max_scale() const {
+	return screen_get_scale(SCREEN_OF_MAIN_WINDOW);
+}
+
+bool DisplayServerEmbedded::window_can_draw(WindowID p_window) const {
+	return true;
+}
+
+bool DisplayServerEmbedded::can_any_window_draw() const {
+	return true;
+}
+
+bool DisplayServerEmbedded::is_touchscreen_available() const {
+	return true;
+}
+
+void DisplayServerEmbedded::resize_window(Size2i p_size, WindowID p_id) {
+	Size2i size = p_size * content_scale;
+
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		rendering_context->window_set_size(p_id, size.x, size.y);
+	}
+#endif
+
+	Variant resize_rect = Rect2i(Point2i(), size);
+	_window_callback(window_resize_callbacks[p_id], resize_rect);
+}
+
+void DisplayServerEmbedded::set_content_scale(float p_scale) {
+	content_scale = p_scale;
+}
+
+void DisplayServerEmbedded::window_set_vsync_mode(DisplayServer::VSyncMode p_vsync_mode, WindowID p_window) {
+	// Not supported
+}
+
+DisplayServer::VSyncMode DisplayServerEmbedded::window_get_vsync_mode(WindowID p_window) const {
+	return DisplayServer::VSYNC_ENABLED;
+}

--- a/servers/display_server_embedded.h
+++ b/servers/display_server_embedded.h
@@ -1,0 +1,190 @@
+/**************************************************************************/
+/*  display_server_embedded.h                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISPLAY_SERVER_EMBEDDED_H
+#define DISPLAY_SERVER_EMBEDDED_H
+
+#include "core/input/input.h"
+#include "servers/display_server.h"
+
+#if defined(RD_ENABLED)
+#include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
+#include "servers/rendering/rendering_device.h"
+#endif
+
+#if defined(GLES3_ENABLED)
+#include "drivers/gles3/rasterizer_gles3.h"
+#endif // GLES3_ENABLED
+
+class DisplayServerEmbedded : public DisplayServer {
+	GDCLASS(DisplayServerEmbedded, DisplayServer)
+
+	_THREAD_SAFE_CLASS_
+
+#if defined(RD_ENABLED)
+	RenderingContextDriver *rendering_context = nullptr;
+	RenderingDevice *rendering_device = nullptr;
+#endif
+	NativeMenu *native_menu = nullptr;
+
+	DisplayServer::ScreenOrientation screen_orientation;
+
+	ObjectID window_attached_instance_id;
+
+	HashMap<WindowID, Callable> window_event_callbacks;
+	HashMap<WindowID, Callable> window_resize_callbacks;
+	HashMap<WindowID, Callable> input_event_callbacks;
+	HashMap<WindowID, Callable> input_text_callbacks;
+
+	float content_scale = 1.0f;
+
+	WindowID window_id_counter = MAIN_WINDOW_ID;
+
+	void perform_event(const Ref<InputEvent> &p_event);
+
+	static Ref<RenderingNativeSurface> native_surface;
+
+	DisplayServerEmbedded(const String &p_rendering_driver, DisplayServer::WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Error &r_error);
+	~DisplayServerEmbedded();
+
+protected:
+	static void _bind_methods();
+
+public:
+	String rendering_driver;
+
+	static DisplayServerEmbedded *get_singleton();
+
+	static void set_native_surface(Ref<RenderingNativeSurface> p_native_handle);
+
+	static void register_embedded_driver();
+	static DisplayServer *create_func(const String &p_rendering_driver, WindowMode p_mode, DisplayServer::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Error &r_error);
+	static Vector<String> get_rendering_drivers_func();
+
+	// MARK: - Events
+
+	virtual void process_events() override;
+
+	virtual void window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_window_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_input_event_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_input_text_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_drop_files_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
+
+	static void _dispatch_input_events(const Ref<InputEvent> &p_event);
+	void send_input_event(const Ref<InputEvent> &p_event, DisplayServer::WindowID p_id = MAIN_WINDOW_ID) const;
+	void send_input_text(const String &p_text, DisplayServer::WindowID p_id = MAIN_WINDOW_ID) const;
+	void send_window_event(DisplayServer::WindowEvent p_event, DisplayServer::WindowID p_id = MAIN_WINDOW_ID) const;
+	void _window_callback(const Callable &p_callable, const Variant &p_arg) const;
+
+	// MARK: - Input
+
+	// MARK: Touches and Apple Pencil
+
+	void touch_press(int p_idx, int p_x, int p_y, bool p_pressed, bool p_double_click);
+	void touch_drag(int p_idx, int p_prev_x, int p_prev_y, int p_x, int p_y, float p_pressure, Vector2 p_tilt);
+	void touches_canceled(int p_idx);
+
+	// MARK: -
+
+	virtual bool has_feature(Feature p_feature) const override;
+	virtual String get_name() const override;
+
+	virtual int get_screen_count() const override;
+	virtual int get_primary_screen() const override;
+	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual float screen_get_refresh_rate(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+
+	virtual Vector<DisplayServer::WindowID> get_window_list() const override;
+
+	virtual WindowID get_window_at_screen_position(const Point2i &p_position) const override;
+
+	virtual WindowID create_native_window(Ref<RenderingNativeSurface> p_native_window) override;
+	virtual bool is_native_window(WindowID p_id) override;
+	virtual void delete_native_window(WindowID p_id) override;
+
+	virtual int64_t window_get_native_handle(HandleType p_handle_type, WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual void window_attach_instance_id(ObjectID p_instance, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual ObjectID window_get_attached_instance_id(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) override;
+
+	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const override;
+	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID) override;
+
+	virtual Point2i window_get_position(WindowID p_window = MAIN_WINDOW_ID) const override;
+	virtual Point2i window_get_position_with_decorations(WindowID p_window = MAIN_WINDOW_ID) const override;
+	virtual void window_set_position(const Point2i &p_position, WindowID p_window = MAIN_WINDOW_ID) override;
+
+	virtual void window_set_transient(WindowID p_window, WindowID p_parent) override;
+
+	virtual void window_set_max_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual Size2i window_get_max_size(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual void window_set_min_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual Size2i window_get_min_size(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual void window_set_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual Size2i window_get_size(WindowID p_window = MAIN_WINDOW_ID) const override;
+	virtual Size2i window_get_size_with_decorations(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual void window_set_mode(WindowMode p_mode, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual WindowMode window_get_mode(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual bool window_is_maximize_allowed(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual void window_set_flag(WindowFlags p_flag, bool p_enabled, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual bool window_get_flag(WindowFlags p_flag, WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual void window_request_attention(WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_move_to_foreground(WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual bool window_is_focused(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual float screen_get_max_scale() const override;
+
+	virtual bool window_can_draw(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual bool can_any_window_draw() const override;
+
+	virtual void window_set_vsync_mode(DisplayServer::VSyncMode p_vsync_mode, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual DisplayServer::VSyncMode window_get_vsync_mode(WindowID p_vsync_mode) const override;
+
+	virtual bool is_touchscreen_available() const override;
+
+	void resize_window(Size2i size, WindowID p_id);
+	void set_content_scale(float p_scale);
+	virtual void swap_buffers() override {}
+};
+
+#endif // DISPLAY_SERVER_EMBEDDED_H

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -59,6 +59,7 @@
 #include "debugger/servers_debugger.h"
 #include "display/native_menu.h"
 #include "display_server.h"
+#include "display_server_embedded.h"
 #include "movie_writer/movie_writer.h"
 #include "movie_writer/movie_writer_mjpeg.h"
 #include "movie_writer/movie_writer_pngwav.h"
@@ -70,6 +71,7 @@
 #include "rendering/renderer_rd/uniform_set_cache_rd.h"
 #include "rendering/rendering_device.h"
 #include "rendering/rendering_device_binds.h"
+#include "rendering/rendering_native_surface.h"
 #include "rendering/storage/render_data.h"
 #include "rendering/storage/render_scene_buffers.h"
 #include "rendering/storage/render_scene_data.h"
@@ -144,6 +146,16 @@ static bool has_server_feature_callback(const String &p_feature) {
 static MovieWriterMJPEG *writer_mjpeg = nullptr;
 static MovieWriterPNGWAV *writer_pngwav = nullptr;
 
+void register_core_server_types() {
+	OS::get_singleton()->benchmark_begin_measure("Servers", "Register Core Extensions");
+	GDREGISTER_ABSTRACT_CLASS(DisplayServer);
+	GDREGISTER_ABSTRACT_CLASS(DisplayServerEmbedded);
+	OS::get_singleton()->benchmark_end_measure("Servers", "Register Core Extensions");
+}
+
+void unregister_core_server_types() {
+}
+
 void register_server_types() {
 	OS::get_singleton()->benchmark_begin_measure("Servers", "Register Extensions");
 
@@ -161,7 +173,6 @@ void register_server_types() {
 
 	OS::get_singleton()->set_has_server_feature_callback(has_server_feature_callback);
 
-	GDREGISTER_ABSTRACT_CLASS(DisplayServer);
 	GDREGISTER_ABSTRACT_CLASS(RenderingServer);
 	GDREGISTER_CLASS(AudioServer);
 
@@ -240,6 +251,8 @@ void register_server_types() {
 	GDREGISTER_CLASS(RDShaderSPIRV);
 	GDREGISTER_CLASS(RDShaderFile);
 	GDREGISTER_CLASS(RDPipelineSpecializationConstant);
+
+	GDREGISTER_ABSTRACT_CLASS(RenderingNativeSurface);
 
 	GDREGISTER_ABSTRACT_CLASS(RenderData);
 	GDREGISTER_CLASS(RenderDataExtension);

--- a/servers/register_server_types.h
+++ b/servers/register_server_types.h
@@ -31,6 +31,9 @@
 #ifndef REGISTER_SERVER_TYPES_H
 #define REGISTER_SERVER_TYPES_H
 
+void register_core_server_types();
+void unregister_core_server_types();
+
 void register_server_types();
 void unregister_server_types();
 

--- a/servers/rendering/rendering_context_driver.cpp
+++ b/servers/rendering/rendering_context_driver.cpp
@@ -42,8 +42,8 @@ RenderingContextDriver::SurfaceID RenderingContextDriver::surface_get_from_windo
 	}
 }
 
-Error RenderingContextDriver::window_create(DisplayServer::WindowID p_window, const void *p_platform_data) {
-	SurfaceID surface = surface_create(p_platform_data);
+Error RenderingContextDriver::window_create(DisplayServer::WindowID p_window, Ref<RenderingNativeSurface> p_native_surface) {
+	SurfaceID surface = surface_create(p_native_surface);
 	if (surface != 0) {
 		window_surface_map[p_window] = surface;
 		return OK;
@@ -56,6 +56,14 @@ void RenderingContextDriver::window_set_size(DisplayServer::WindowID p_window, u
 	SurfaceID surface = surface_get_from_window(p_window);
 	if (surface) {
 		surface_set_size(surface, p_width, p_height);
+	}
+}
+
+void RenderingContextDriver::window_get_size(DisplayServer::WindowID p_window, uint32_t &r_width, uint32_t &r_height) {
+	SurfaceID surface = surface_get_from_window(p_window);
+	if (surface) {
+		r_width = surface_get_width(surface);
+		r_height = surface_get_height(surface);
 	}
 }
 

--- a/servers/rendering/rendering_context_driver.h
+++ b/servers/rendering/rendering_context_driver.h
@@ -32,6 +32,7 @@
 #define RENDERING_CONTEXT_DRIVER_H
 
 #include "core/object/object.h"
+#include "rendering_native_surface.h"
 #include "servers/display_server.h"
 
 class RenderingDeviceDriver;
@@ -45,8 +46,9 @@ private:
 
 public:
 	SurfaceID surface_get_from_window(DisplayServer::WindowID p_window) const;
-	Error window_create(DisplayServer::WindowID p_window, const void *p_platform_data);
+	Error window_create(DisplayServer::WindowID p_window, Ref<RenderingNativeSurface> p_native_surface);
 	void window_set_size(DisplayServer::WindowID p_window, uint32_t p_width, uint32_t p_height);
+	void window_get_size(DisplayServer::WindowID p_window, uint32_t &r_width, uint32_t &r_height);
 	void window_set_vsync_mode(DisplayServer::WindowID p_window, DisplayServer::VSyncMode p_vsync_mode);
 	DisplayServer::VSyncMode window_get_vsync_mode(DisplayServer::WindowID p_window) const;
 	void window_destroy(DisplayServer::WindowID p_window);
@@ -86,7 +88,7 @@ public:
 	virtual bool device_supports_present(uint32_t p_device_index, SurfaceID p_surface) const = 0;
 	virtual RenderingDeviceDriver *driver_create() = 0;
 	virtual void driver_free(RenderingDeviceDriver *p_driver) = 0;
-	virtual SurfaceID surface_create(const void *p_platform_data) = 0;
+	virtual SurfaceID surface_create(Ref<RenderingNativeSurface> p_native_surface) = 0;
 	virtual void surface_set_size(SurfaceID p_surface, uint32_t p_width, uint32_t p_height) = 0;
 	virtual void surface_set_vsync_mode(SurfaceID p_surface, DisplayServer::VSyncMode p_vsync_mode) = 0;
 	virtual DisplayServer::VSyncMode surface_get_vsync_mode(SurfaceID p_surface) const = 0;

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -344,7 +344,7 @@ public:
 		BARRIER_ACCESS_FRAGMENT_SHADING_RATE_ATTACHMENT_READ_BIT = (1 << 23),
 	};
 
-	struct MemoryBarrier {
+	struct MemoryAccessBarrier {
 		BitField<BarrierAccessBits> src_access;
 		BitField<BarrierAccessBits> dst_access;
 	};
@@ -370,7 +370,7 @@ public:
 			CommandBufferID p_cmd_buffer,
 			BitField<PipelineStageBits> p_src_stages,
 			BitField<PipelineStageBits> p_dst_stages,
-			VectorView<MemoryBarrier> p_memory_barriers,
+			VectorView<MemoryAccessBarrier> p_memory_barriers,
 			VectorView<BufferBarrier> p_buffer_barriers,
 			VectorView<TextureBarrier> p_texture_barriers) = 0;
 

--- a/servers/rendering/rendering_device_graph.cpp
+++ b/servers/rendering/rendering_device_graph.cpp
@@ -1015,7 +1015,7 @@ void RenderingDeviceGraph::_group_barriers_for_render_commands(RDD::CommandBuffe
 		return;
 	}
 
-	const VectorView<RDD::MemoryBarrier> memory_barriers = !is_memory_barrier_empty ? barrier_group.memory_barrier : VectorView<RDD::MemoryBarrier>();
+	const VectorView<RDD::MemoryAccessBarrier> memory_barriers = !is_memory_barrier_empty ? barrier_group.memory_barrier : VectorView<RDD::MemoryAccessBarrier>();
 	const VectorView<RDD::TextureBarrier> texture_barriers = barrier_group.normalization_barriers.is_empty() ? barrier_group.transition_barriers : barrier_group.normalization_barriers;
 #if USE_BUFFER_BARRIERS
 	const VectorView<RDD::BufferBarrier> buffer_barriers = !are_buffer_barriers_empty ? barrier_group.buffer_barriers : VectorView<RDD::BufferBarrier>();
@@ -1027,7 +1027,7 @@ void RenderingDeviceGraph::_group_barriers_for_render_commands(RDD::CommandBuffe
 
 	bool separate_texture_barriers = !barrier_group.normalization_barriers.is_empty() && !barrier_group.transition_barriers.is_empty();
 	if (separate_texture_barriers) {
-		driver->command_pipeline_barrier(p_command_buffer, barrier_group.src_stages, barrier_group.dst_stages, VectorView<RDD::MemoryBarrier>(), VectorView<RDD::BufferBarrier>(), barrier_group.transition_barriers);
+		driver->command_pipeline_barrier(p_command_buffer, barrier_group.src_stages, barrier_group.dst_stages, VectorView<RDD::MemoryAccessBarrier>(), VectorView<RDD::BufferBarrier>(), barrier_group.transition_barriers);
 	}
 }
 

--- a/servers/rendering/rendering_device_graph.h
+++ b/servers/rendering/rendering_device_graph.h
@@ -102,7 +102,7 @@ public:
 
 		Type type = TYPE_NONE;
 		int32_t adjacent_command_list_index = -1;
-		RDD::MemoryBarrier memory_barrier;
+		RDD::MemoryAccessBarrier memory_barrier;
 		int32_t normalization_barrier_index = -1;
 		int normalization_barrier_count = 0;
 		int32_t transition_barrier_index = -1;
@@ -525,7 +525,7 @@ private:
 	struct BarrierGroup {
 		BitField<RDD::PipelineStageBits> src_stages;
 		BitField<RDD::PipelineStageBits> dst_stages;
-		RDD::MemoryBarrier memory_barrier;
+		RDD::MemoryAccessBarrier memory_barrier;
 		LocalVector<RDD::TextureBarrier> normalization_barriers;
 		LocalVector<RDD::TextureBarrier> transition_barriers;
 #if USE_BUFFER_BARRIERS

--- a/servers/rendering/rendering_native_surface.cpp
+++ b/servers/rendering/rendering_native_surface.cpp
@@ -1,0 +1,40 @@
+/**************************************************************************/
+/*  rendering_native_surface.cpp                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "rendering_native_surface.h"
+
+void RenderingNativeSurface::_bind_methods() {
+}
+
+RenderingNativeSurface::RenderingNativeSurface() {
+}
+
+RenderingNativeSurface::~RenderingNativeSurface() {
+}

--- a/servers/rendering/rendering_native_surface.h
+++ b/servers/rendering/rendering_native_surface.h
@@ -1,0 +1,51 @@
+/**************************************************************************/
+/*  rendering_native_surface.h                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef RENDERING_NATIVE_SURFACE_H
+#define RENDERING_NATIVE_SURFACE_H
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+
+class RenderingContextDriver;
+
+class RenderingNativeSurface : public RefCounted {
+	GDCLASS(RenderingNativeSurface, RefCounted);
+
+	static void _bind_methods();
+
+public:
+	RenderingNativeSurface();
+	~RenderingNativeSurface();
+
+	virtual RenderingContextDriver *create_rendering_context() = 0;
+};
+
+#endif // RENDERING_NATIVE_SURFACE_H

--- a/thirdparty/misc/mikktspace.c
+++ b/thirdparty/misc/mikktspace.c
@@ -1448,9 +1448,11 @@ static void QuickSort(int* pSortBuffer, int iLeft, int iRight, unsigned int uSee
 	int iL, iR, n, index, iMid, iTmp;
 
 	// Random
-	unsigned int t=uSeed&31;
-	t=(uSeed<<t)|(uSeed>>(32-t));
-	uSeed=uSeed+t+3;
+	unsigned int t = uSeed & 31;
+	if(t != 0){
+		t = (uSeed << t) | (uSeed >> (32 - t));
+	}
+	uSeed = uSeed + t + 3;
 	// Random end
 
 	iL=iLeft; iR=iRight;


### PR DESCRIPTION
We can now add Godot Engine to where it doesn't belong.

## Changes

1. Renamed MemoryBarrier to MemoryAccessBarrier.
2. Resolve Windows build issues

## Original

* Add a new GodotInstance GDCLASS that provides startup, shutdown and iteration commands
* Add a new GDExtension entry point that creates a new Godot instance and returns a GodotInstance object. * This object can be used to control the GodotInstance.
* Allow specifying an external native rendering surface handle to render Godot into the UI of a host application.
  * It is also possible to embed multiple Godot windows into the UI of a host application. * Currently supported on MacOS and iOS

Sample Apps: https://github.com/V-Sekai/libgodot_project

Developed by [Migeran](https://migeran.com) & [V-Sekai](https://github.com/V-Sekai)

Sponsors & Acknowledgements:

* Initial development sponsored by [Smirk Software](https://www.smirk.gg/)
* Rebasing to Godot 4.3 and further development sponsored by [Xibbon Inc.](https://xibbon.com) * The GDExtension registration of the host process & build system changes were based
  on @Faolan-Rad's LibGodot PR: https://github.com/godotengine/godot/pull/72883

Co-Authored-By: Gabor Koncz <gabor.koncz@migeran.com>