### PR TITLE
Fix AEC3 submodule android/web build

### DIFF
--- a/modules/speech/config.py
+++ b/modules/speech/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return platform != "web" and platform != "android"
+    return True
 
 
 def configure(env):

--- a/modules/speech/thirdparty/AEC3/base/rtc_base/platform_thread_types.cc
+++ b/modules/speech/thirdparty/AEC3/base/rtc_base/platform_thread_types.cc
@@ -10,7 +10,7 @@
 
 #include "rtc_base/platform_thread_types.h"
 
-#if defined(WEBRTC_LINUX)
+#if defined(WEBRTC_LINUX) || defined(WEBRTC_ANDROID)
 #include <sys/prctl.h>
 #include <sys/syscall.h>
 #endif


### PR DESCRIPTION
Enable AEC3 build on android/web builds.
On Android build PR_SET_NAME wasn't set, so prtcl.h was included to solve error here
https://github.com/V-Sekai/godot/blob/6229913ade04cdf8baec1afe584abb1211811692/modules/speech/thirdparty/AEC3/base/rtc_base/platform_thread_types.cc#L81-L83